### PR TITLE
Hide floating connection status UI in lobby

### DIFF
--- a/DuckGame/src/DuckGame/Network/DuckNetwork.cs
+++ b/DuckGame/src/DuckGame/Network/DuckNetwork.cs
@@ -1148,6 +1148,10 @@ namespace DuckGame
             _core._ducknetMenu.Open();
             MonoMain.pauseMenu = _ducknetUIGroup;
             HUD.AddCornerControl(HUDCorner.BottomRight, "@CHAT@CHAT");
+            if (Level.current is GameLevel)
+                HUD.AddCornerControl(HUDCorner.BottomLeft, "@F1@PING");
+            else if (Network.isServer && (Level.current is TeamSelect2) && !DuckNetwork.TryPeacefulResolution(false))
+                HUD.AddCornerControl(HUDCorner.BottomLeft, "@F1@+@SELECT@FORCE START");
             _core._pauseOpen = true;
             SFX.Play("pause", 0.6f);
         }
@@ -1890,7 +1894,7 @@ namespace DuckGame
                     }
                     _core._menuClosed.value = false;
                 }
-                if (Keyboard.Pressed(Keys.F1) && !Keyboard.Down(Keys.LeftShift) && !Keyboard.Down(Keys.RightShift))
+                if (Keyboard.Pressed(Keys.F1) && !(Level.current is TeamSelect2))
                     ConnectionStatusUI.Show();
                 if (core.logTransferSize > 0)
                     ConnectionStatusUI.core.tempShow = 2;

--- a/DuckGame/src/MonoTime/Input/Input.cs
+++ b/DuckGame/src/MonoTime/Input/Input.cs
@@ -934,6 +934,7 @@ namespace DuckGame
             DuckGame.Input._triggerImageMap.Add("RETICULE", new Sprite("challenge/reticule"));
             DuckGame.Input._triggerImageMap.Add("TICKET", new Sprite("arcade/ticket"));
             DuckGame.Input._triggerImageMap.Add("CHECK", new Sprite("checkIcon"));
+            DuckGame.Input._triggerImageMap.Add("F1", new Sprite("buttons/keyboard/f1"));
             DuckGame.Input._triggerImageMap.Add("DGR", new Sprite("DGR") { center = new Vec2(0, 0.75f) });
             DuckGame.Input._triggerImageMap.Add("DGRBIG", new Sprite("DGRBIG"));
             Dictionary<string, Sprite> triggerImageMap = DuckGame.Input._triggerImageMap;


### PR DESCRIPTION
Prevent the floating connection status UI from popping up when holding F1 in lobby for a cleaner force start/resume experience.

Additionally, when pausing
- in lobby, a corner tip for the force start keybind (F1 + SELECT) is displayed for the host (but only if a force start is possible at all).
- in game, a corner tip for opening up the connection status UI (F1) is displayed instead for everyone.