### PR TITLE
Editor QOL fixes

### DIFF
--- a/DuckGame/DuckGame.csproj
+++ b/DuckGame/DuckGame.csproj
@@ -99,7 +99,7 @@
     <OutputPath>..\bin\</OutputPath>
     <DefineConstants>TRACE;DuckGame</DefineConstants>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-    <Optimize>false</Optimize>
+    <Optimize>true</Optimize>
     <DebugType>pdbonly</DebugType>
     <PlatformTarget>x86</PlatformTarget>
     <ErrorReport>prompt</ErrorReport>

--- a/DuckGame/src/DuckGame/Stuff/Teleporter.cs
+++ b/DuckGame/src/DuckGame/Stuff/Teleporter.cs
@@ -359,11 +359,11 @@ namespace DuckGame
                 if (direction == 0)
                     _arrow.angleDegrees = 0f;
                 else if (direction == 1)
-                    _arrow.angleDegrees = 180f;
-                else if (direction == 2)
-                    _arrow.angleDegrees = -90f;
-                else if (direction == 3)
                     _arrow.angleDegrees = 90f;
+                else if (direction == 2)
+                    _arrow.angleDegrees = 180f;
+                else if (direction == 3)
+                    _arrow.angleDegrees = -90f;
                 Graphics.Draw(_arrow, (float)(x - 8.0 + (int)teleHeight * 16 / 2 + (float)_float * 2.0), y);
             }
             else
@@ -384,11 +384,11 @@ namespace DuckGame
                 if (direction == 0)
                     _arrow.angleDegrees = 0f;
                 else if (direction == 1)
-                    _arrow.angleDegrees = 180f;
-                else if (direction == 2)
-                    _arrow.angleDegrees = -90f;
-                else if (direction == 3)
                     _arrow.angleDegrees = 90f;
+                else if (direction == 2)
+                    _arrow.angleDegrees = 180f;
+                else if (direction == 3)
+                    _arrow.angleDegrees = -90f;
                 Graphics.Draw(_arrow, x, (float)(y + 8.0 - (int)teleHeight * 16 / 2 + (float)_float * 2.0));
             }
         }
@@ -433,9 +433,9 @@ namespace DuckGame
         {
             EditorGroupMenu contextMenu = base.GetContextMenu() as EditorGroupMenu;
             contextMenu.AddItem(new ContextRadio("Up", direction == 0, 0, null, new FieldBinding(this, "direction")));
-            contextMenu.AddItem(new ContextRadio("Down", direction == 1, 1, null, new FieldBinding(this, "direction")));
-            contextMenu.AddItem(new ContextRadio("Left", direction == 2, 2, null, new FieldBinding(this, "direction")));
-            contextMenu.AddItem(new ContextRadio("Right", direction == 3, 3, null, new FieldBinding(this, "direction")));
+            contextMenu.AddItem(new ContextRadio("Down", direction == 2, 2, null, new FieldBinding(this, "direction")));
+            contextMenu.AddItem(new ContextRadio("Left", direction == 3, 3, null, new FieldBinding(this, "direction")));
+            contextMenu.AddItem(new ContextRadio("Right", direction == 1, 1, null, new FieldBinding(this, "direction")));
             return contextMenu;
         }
 

--- a/DuckGame/src/DuckGame/Stuff/Wires/WireButton.cs
+++ b/DuckGame/src/DuckGame/Stuff/Wires/WireButton.cs
@@ -1,11 +1,4 @@
-﻿// Decompiled with JetBrains decompiler
-// Type: DuckGame.WireButton
-//removed for regex reasons Culture=neutral, PublicKeyToken=null
-// MVID: C907F20B-C12B-4773-9B1E-25290117C0E4
-// Assembly location: D:\Program Files (x86)\Steam\steamapps\common\Duck Game\DuckGame.exe
-// XML documentation location: D:\Program Files (x86)\Steam\steamapps\common\Duck Game\DuckGame.xml
-
-using System.Linq;
+﻿using System.Linq;
 
 namespace DuckGame
 {
@@ -59,10 +52,8 @@ namespace DuckGame
         {
             if (flipHorizontal)
             {
-                if (orientation.value == 1)
-                    orientation.value = 3;
-                else if (orientation.value == 3)
-                    orientation.value = 1;
+                if ((orientation.value & 1) == 1) // If odd, flip the bit. 1 -> 3, 3 -> 1
+                    orientation.value ^= 2;
             }
             angleDegrees = orientation.value * 90f;
             if (!(Level.current is Editor))
@@ -156,7 +147,7 @@ namespace DuckGame
             if (Level.current is Editor)
             {
                 angleDegrees = orientation.value * 90f;
-                if (flipHorizontal)
+                if (flipHorizontal && (orientation.value & 1) != 0)  // make consistent with actual outcome on play
                     angleDegrees -= 180f;
             }
             else


### PR DESCRIPTION
Turns code optimizations on

Make teleporter rotate clockwise in editor when pressing tab

Optimize button orientation code (lmk if the bit editing is too unreadable but imo with the comment its fine)

Make button not flip in editor if it's facing up or down and the flipped check is on, to be consistent with how it is while playing