### PR TITLE
Tab entity/property cycling

### DIFF
--- a/DuckGame/src/DuckGame/Backgrounds/CityBackground.cs
+++ b/DuckGame/src/DuckGame/Backgrounds/CityBackground.cs
@@ -33,6 +33,7 @@ namespace DuckGame
             layer = Layer.Foreground;
             _visibleInGame = false;
             _editorName = "City BG";
+            editorCycleType = typeof(DonutSpaceBackground);
         }
 
         public override void Initialize()

--- a/DuckGame/src/DuckGame/Backgrounds/DonutSpaceBackground.cs
+++ b/DuckGame/src/DuckGame/Backgrounds/DonutSpaceBackground.cs
@@ -29,6 +29,7 @@ namespace DuckGame
             _speedMult = speedMult;
             _moving = moving;
             _editorName = "Donut BG";
+            editorCycleType = typeof(IndustrialBackground);
         }
 
         public override void Initialize()

--- a/DuckGame/src/DuckGame/Backgrounds/IndustrialBackground.cs
+++ b/DuckGame/src/DuckGame/Backgrounds/IndustrialBackground.cs
@@ -25,6 +25,7 @@ namespace DuckGame
             layer = Layer.Foreground;
             _visibleInGame = false;
             _editorName = "Industrial BG";
+            editorCycleType = typeof(KingdomBackground);
         }
 
         public override void Initialize()

--- a/DuckGame/src/DuckGame/Backgrounds/KingdomBackground.cs
+++ b/DuckGame/src/DuckGame/Backgrounds/KingdomBackground.cs
@@ -30,6 +30,7 @@ namespace DuckGame
             _speedMult = speedMult;
             _moving = moving;
             _editorName = "Kingdom BG";
+            editorCycleType = typeof(NatureBackground);
         }
 
         public override void Initialize()

--- a/DuckGame/src/DuckGame/Backgrounds/NatureBackground.cs
+++ b/DuckGame/src/DuckGame/Backgrounds/NatureBackground.cs
@@ -26,6 +26,7 @@ namespace DuckGame
             layer = Layer.Foreground;
             _visibleInGame = false;
             _editorName = "Nature BG";
+            editorCycleType = typeof(NatureBackgroundNight);
         }
 
         public override void Initialize()

--- a/DuckGame/src/DuckGame/Backgrounds/NatureBackgroundNight.cs
+++ b/DuckGame/src/DuckGame/Backgrounds/NatureBackgroundNight.cs
@@ -25,6 +25,7 @@ namespace DuckGame
             layer = Layer.Foreground;
             _visibleInGame = false;
             _editorName = "Nature BG Night";
+            editorCycleType = typeof(OfficeBackground);
         }
 
         public override void Initialize()

--- a/DuckGame/src/DuckGame/Backgrounds/OfficeBackground.cs
+++ b/DuckGame/src/DuckGame/Backgrounds/OfficeBackground.cs
@@ -24,6 +24,7 @@ namespace DuckGame
             layer = Layer.Foreground;
             _visibleInGame = false;
             _editorName = "Office BG";
+            editorCycleType = typeof(PyramidBackground);
         }
 
         public override void Initialize()

--- a/DuckGame/src/DuckGame/Backgrounds/PyramidBackground.cs
+++ b/DuckGame/src/DuckGame/Backgrounds/PyramidBackground.cs
@@ -24,6 +24,7 @@ namespace DuckGame
             layer = Layer.Foreground;
             _visibleInGame = false;
             _editorName = "Pyramid BG";
+            editorCycleType = typeof(SnowBackground);
         }
 
         public override void Initialize()

--- a/DuckGame/src/DuckGame/Backgrounds/SnowBackground.cs
+++ b/DuckGame/src/DuckGame/Backgrounds/SnowBackground.cs
@@ -25,6 +25,7 @@ namespace DuckGame
             layer = Layer.Foreground;
             _visibleInGame = false;
             _editorName = "Snow BG";
+            editorCycleType = typeof(SpaceBackground);
         }
 
         public override void Initialize()

--- a/DuckGame/src/DuckGame/Backgrounds/SpaceBackground.cs
+++ b/DuckGame/src/DuckGame/Backgrounds/SpaceBackground.cs
@@ -30,6 +30,7 @@ namespace DuckGame
             _speedMult = speedMult;
             _moving = moving;
             _editorName = "Space BG";
+            editorCycleType = typeof(VirtualBackground);
         }
 
         public override void Initialize()

--- a/DuckGame/src/DuckGame/Backgrounds/UndergroundBackground.cs
+++ b/DuckGame/src/DuckGame/Backgrounds/UndergroundBackground.cs
@@ -32,6 +32,7 @@ namespace DuckGame
             _moving = moving;
             _editorName = "Bunker BG";
             _yParallax = false;
+            editorCycleType = typeof(CityBackground);
         }
 
         public override void Initialize()

--- a/DuckGame/src/DuckGame/Backgrounds/VirtualBackground.cs
+++ b/DuckGame/src/DuckGame/Backgrounds/VirtualBackground.cs
@@ -49,6 +49,7 @@ namespace DuckGame
             _editorName = "Virtual";
             _realBackground = realBackground;
             _foreground = fore;
+            editorCycleType = typeof(UndergroundBackground);
         }
 
         public static void InitializeBack()

--- a/DuckGame/src/DuckGame/Spawners/ItemBox.cs
+++ b/DuckGame/src/DuckGame/Spawners/ItemBox.cs
@@ -58,6 +58,7 @@ namespace DuckGame
             _canFlip = false;
             _placementCost += 4;
             editorTooltip = "Spawns a copy of the contained item any time it's used. Recharges after a short duration.";
+            editorCycleType = typeof(ItemBoxOneTime);
         }
 
         public override void Initialize()

--- a/DuckGame/src/DuckGame/Spawners/ItemBoxOneTime.cs
+++ b/DuckGame/src/DuckGame/Spawners/ItemBoxOneTime.cs
@@ -16,6 +16,7 @@ namespace DuckGame
           : base(xpos, ypos)
         {
             editorTooltip = "Spawns the contained item one time when it's used.";
+            editorCycleType = typeof(ItemBoxRandom);
         }
 
         public override void UpdateCharging() => charging = 500;

--- a/DuckGame/src/DuckGame/Spawners/ItemBoxRandom.cs
+++ b/DuckGame/src/DuckGame/Spawners/ItemBoxRandom.cs
@@ -18,6 +18,7 @@ namespace DuckGame
           : base(xpos, ypos)
         {
             editorTooltip = "Spawns a random object each time it's used. Recharges after a short duration.";
+            editorCycleType = typeof(ItemBox);
         }
 
         public override void Draw()

--- a/DuckGame/src/DuckGame/Special/CameraBoundsNew.cs
+++ b/DuckGame/src/DuckGame/Special/CameraBoundsNew.cs
@@ -21,6 +21,7 @@ namespace DuckGame
             editorTooltip = "A boundary that keeps moving cameras locked within it!";
             Wide._tooltip = "Width of the boundary area (in Pixels)";
             High._tooltip = "Height of the boundary area (in Pixels)";
+            editorCycleType = typeof(CameraFixed);
         }
 
         public override void Initialize()

--- a/DuckGame/src/DuckGame/Special/CameraFixed.cs
+++ b/DuckGame/src/DuckGame/Special/CameraFixed.cs
@@ -30,6 +30,7 @@ namespace DuckGame
             collisionSize = new Vec2(8f, 8f);
             collisionOffset = new Vec2(-4f, -4f);
             _visibleInGame = false;
+            editorCycleType = typeof(CameraMover);
         }
 
         public override void Initialize()

--- a/DuckGame/src/DuckGame/Special/CameraMover.cs
+++ b/DuckGame/src/DuckGame/Special/CameraMover.cs
@@ -22,6 +22,7 @@ namespace DuckGame
             center = new Vec2(8f, 8f);
             collisionSize = new Vec2(8f, 8f);
             collisionOffset = new Vec2(-4f, -4f);
+            editorCycleType = typeof(CameraZoomNew);
         }
 
         public override void Initialize()

--- a/DuckGame/src/DuckGame/Special/CameraZoomNew.cs
+++ b/DuckGame/src/DuckGame/Special/CameraZoomNew.cs
@@ -24,6 +24,7 @@ namespace DuckGame
             Allow_Warps._tooltip = "If enabled, the camera will instantly move to follow Faster-Than-Light ducks";
             Overfollow._tooltip = "If enabled, the camera will keep a tighter focus on fast moving Ducks (think Chainsaw challenges!)";
             graphic = new Sprite("cameraIcon");
+            editorCycleType = typeof(CameraBoundsNew);
         }
 
         public override void Initialize()

--- a/DuckGame/src/DuckGame/Special/NewGoodys.cs
+++ b/DuckGame/src/DuckGame/Special/NewGoodys.cs
@@ -30,6 +30,7 @@ namespace DuckGame
             _editorName = "Goody";
             _contextMenuFilter.Add("Sequence");
             sequence._resetLikelyhood = false;
+            editorCycleType = typeof(RandomControllerNew);
         }
 
         public void UpdateFrame()

--- a/DuckGame/src/DuckGame/Special/RandomControllerNew.cs
+++ b/DuckGame/src/DuckGame/Special/RandomControllerNew.cs
@@ -41,6 +41,7 @@ namespace DuckGame
             collisionOffset = new Vec2(-8f, -8f);
             _canFlip = false;
             _visibleInGame = false;
+            editorCycleType = typeof(TargetDuckNew);
             _editorName = "Random Controller";
             editorTooltip = "Allows you to make it so Targets/Goodies appear randomly.";
             Max_Up._tooltip = "How many Targets/Goodies can be active at once.";

--- a/DuckGame/src/DuckGame/Special/TriggerVolume.cs
+++ b/DuckGame/src/DuckGame/Special/TriggerVolume.cs
@@ -45,6 +45,7 @@ namespace DuckGame
             (graphic as SpriteMap).frame = 3;
             collisionOffset = new Vec2(-4f, -4f);
             collisionSize = new Vec2(8f, 8f);
+            editorCycleType = typeof(GoodyNew);
             _contextMenuFilter.Add("Sequence");
             _editorName = "Trigger Volume";
             editorTooltip = "Pretty much an invisible Goody that you can resize.";

--- a/DuckGame/src/DuckGame/Stuff/FunBeam.cs
+++ b/DuckGame/src/DuckGame/Stuff/FunBeam.cs
@@ -36,6 +36,7 @@ namespace DuckGame
             _editorName = "Fun Beam";
             editorTooltip = "Place 2 generators near each other to create a beam that triggers weapons passing through.";
             hugWalls = WallHug.Left;
+            editorCycleType = typeof(VerticalFunBeam);
         }
 
         public override void OnSoftImpact(MaterialThing with, ImpactedFrom from)

--- a/DuckGame/src/DuckGame/Stuff/Pipes/PipeTileset.cs
+++ b/DuckGame/src/DuckGame/Stuff/Pipes/PipeTileset.cs
@@ -8,6 +8,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Runtime.CompilerServices;
 
 namespace DuckGame
 {
@@ -134,6 +135,31 @@ namespace DuckGame
             searchRight = node.GetProperty<bool>("right");
             _sprite.frame = node.GetProperty<int>("pipeFrame");
             return true;
+        }
+
+        public override Type TabRotate(bool control)
+        {
+            Thing pipetype = this;
+            if (control)
+            {
+                background = !background;
+            }
+            else
+            {
+                switch (pipetype)
+                {
+                    case DuckGame.PipeBlue:
+                        editorCycleType = typeof(PipeRed);
+                        break;
+                    case DuckGame.PipeRed:
+                        editorCycleType = typeof(PipeGreen);
+                        break;
+                    case PipeGreen:
+                        editorCycleType = typeof(PipeBlue);
+                        break;
+                }
+            }
+            return editorCycleType;
         }
 
         public bool isEntryPipe => _validPipe && connections.Count == 1 && !(bool)trapdoor;

--- a/DuckGame/src/DuckGame/Stuff/StandingFluid.cs
+++ b/DuckGame/src/DuckGame/Stuff/StandingFluid.cs
@@ -50,6 +50,14 @@ namespace DuckGame
             }
         }
 
+        public override void TabRotate()
+        {
+            if (fluidType >= 3)
+                fluidType = 0;
+            else
+                ++fluidType;
+        }
+
         public override void Update()
         {
             ++w8;

--- a/DuckGame/src/DuckGame/Stuff/TargetDuckNew.cs
+++ b/DuckGame/src/DuckGame/Stuff/TargetDuckNew.cs
@@ -42,6 +42,7 @@ namespace DuckGame
             _contextMenuFilter.Add("speediness");
             _contextMenuFilter.Add("Sequence");
             sequence._resetLikelyhood = false;
+            editorCycleType = typeof(TriggerVolume);
         }
 
         public override void OnSequenceActivate()

--- a/DuckGame/src/DuckGame/Stuff/VerticalFunBeam.cs
+++ b/DuckGame/src/DuckGame/Stuff/VerticalFunBeam.cs
@@ -22,6 +22,7 @@ namespace DuckGame
             collisionOffset = new Vec2(-5f, -2f);
             collisionSize = new Vec2(10f, 4f);
             _placementCost += 2;
+            editorCycleType = typeof(FunBeam);
         }
 
         public override void Draw()

--- a/DuckGame/src/DuckGame/Stuff/Window.cs
+++ b/DuckGame/src/DuckGame/Stuff/Window.cs
@@ -87,6 +87,22 @@ namespace DuckGame
             base.SetTranslation(translation);
         }
 
+        public override Type TabRotate(bool control)
+        {
+            Window windowtype = this;
+            if (control)
+                bars = !bars;
+            else
+            {
+                if (windowtype.floor)
+                    editorCycleType = typeof(Window);
+                else
+                    editorCycleType = typeof(FloorWindow);
+
+            }
+            return editorCycleType;
+        }
+
         public virtual void UpdateHeight()
         {
             float num = windowHeight.value * 16f;

--- a/DuckGame/src/DuckGame/Thing.cs
+++ b/DuckGame/src/DuckGame/Thing.cs
@@ -705,6 +705,12 @@ namespace DuckGame
             flipHorizontal = !flipHorizontal;
         }
 
+        public virtual Type TabRotate(bool control) // Hack: overloaded function to have dynamicly changing editor types on pressing tab
+        {
+            this.TabRotate();
+            return this.editorCycleType;
+        }
+
         public Layer placementLayer => placementLayerOverride != null ? placementLayerOverride : layer;
 
         public float likelyhoodToExist

--- a/DuckGame/src/DuckGame/Tiles/ArrowSign.cs
+++ b/DuckGame/src/DuckGame/Tiles/ArrowSign.cs
@@ -5,6 +5,8 @@
 // Assembly location: D:\Program Files (x86)\Steam\steamapps\common\Duck Game\DuckGame.exe
 // XML documentation location: D:\Program Files (x86)\Steam\steamapps\common\Duck Game\DuckGame.xml
 
+using System;
+
 namespace DuckGame
 {
     [EditorGroup("Details|Signs")]
@@ -23,6 +25,13 @@ namespace DuckGame
             depth = -0.5f;
             _editorName = "Arrow Sign";
             hugWalls = WallHug.Floor;
+        }
+
+        public override Type TabRotate(bool control)
+        {
+            if (control)
+                return typeof(DangerSign);
+            return base.TabRotate(control);
         }
 
         public override void Draw()

--- a/DuckGame/src/DuckGame/Tiles/Bulb.cs
+++ b/DuckGame/src/DuckGame/Tiles/Bulb.cs
@@ -26,6 +26,7 @@ namespace DuckGame
             depth = (Depth)0.9f;
             hugWalls = WallHug.Ceiling;
             layer = Layer.Game;
+            editorCycleType = typeof(HangingCityLight);
         }
 
         public override void Initialize()

--- a/DuckGame/src/DuckGame/Tiles/ClippingSign.cs
+++ b/DuckGame/src/DuckGame/Tiles/ClippingSign.cs
@@ -5,6 +5,8 @@
 // Assembly location: D:\Program Files (x86)\Steam\steamapps\common\Duck Game\DuckGame.exe
 // XML documentation location: D:\Program Files (x86)\Steam\steamapps\common\Duck Game\DuckGame.xml
 
+using System;
+
 namespace DuckGame
 {
     [EditorGroup("Details|Signs")]
@@ -29,6 +31,13 @@ namespace DuckGame
             editorTooltip = "I mean it!!";
             _canFlip = false;
             hugWalls = WallHug.Floor;
+        }
+
+        public override Type TabRotate(bool control)
+        {
+            if (control)
+                return typeof(RaceSign);
+            return base.TabRotate(control);
         }
 
         public override void Draw() => base.Draw();

--- a/DuckGame/src/DuckGame/Tiles/DangerSign.cs
+++ b/DuckGame/src/DuckGame/Tiles/DangerSign.cs
@@ -5,6 +5,8 @@
 // Assembly location: D:\Program Files (x86)\Steam\steamapps\common\Duck Game\DuckGame.exe
 // XML documentation location: D:\Program Files (x86)\Steam\steamapps\common\Duck Game\DuckGame.xml
 
+using System;
+
 namespace DuckGame
 {
     [EditorGroup("Details|Signs")]
@@ -25,6 +27,13 @@ namespace DuckGame
             _editorName = "Danger Sign";
             hugWalls = WallHug.Floor;
             shouldbeinupdateloop = false;
+        }
+
+        public override Type TabRotate(bool control)
+        {
+            if (control)
+                return typeof(EasySign);
+            return base.TabRotate(control);
         }
 
         public override void Draw()

--- a/DuckGame/src/DuckGame/Tiles/EasySign.cs
+++ b/DuckGame/src/DuckGame/Tiles/EasySign.cs
@@ -5,6 +5,8 @@
 // Assembly location: D:\Program Files (x86)\Steam\steamapps\common\Duck Game\DuckGame.exe
 // XML documentation location: D:\Program Files (x86)\Steam\steamapps\common\Duck Game\DuckGame.xml
 
+using System;
+
 namespace DuckGame
 {
     [EditorGroup("Details|Signs")]
@@ -23,6 +25,13 @@ namespace DuckGame
             depth = -0.5f;
             _editorName = "Easy Sign";
             hugWalls = WallHug.Floor;
+        }
+
+        public override Type TabRotate(bool control)
+        {
+            if (control)
+                return typeof(FishinSign);
+            return base.TabRotate(control);
         }
 
         public override void Draw()

--- a/DuckGame/src/DuckGame/Tiles/FishinSign.cs
+++ b/DuckGame/src/DuckGame/Tiles/FishinSign.cs
@@ -5,6 +5,8 @@
 // Assembly location: D:\Program Files (x86)\Steam\steamapps\common\Duck Game\DuckGame.exe
 // XML documentation location: D:\Program Files (x86)\Steam\steamapps\common\Duck Game\DuckGame.xml
 
+using System;
+
 namespace DuckGame
 {
     [EditorGroup("Details|Signs")]
@@ -24,6 +26,13 @@ namespace DuckGame
             _editorName = "Fishin Sign";
             editorTooltip = "It really explains itself, doesn't it?";
             hugWalls = WallHug.Floor;
+        }
+
+        public override Type TabRotate(bool control)
+        {
+            if (control)
+                return typeof(HardLeft);
+            return base.TabRotate(control);
         }
 
         public override void Draw()

--- a/DuckGame/src/DuckGame/Tiles/HangingCityLight.cs
+++ b/DuckGame/src/DuckGame/Tiles/HangingCityLight.cs
@@ -26,6 +26,7 @@ namespace DuckGame
             depth = (Depth)0.9f;
             hugWalls = WallHug.Ceiling;
             layer = Layer.Game;
+            editorCycleType = typeof(Lamp);
         }
 
         public override void Initialize()

--- a/DuckGame/src/DuckGame/Tiles/HardLeft.cs
+++ b/DuckGame/src/DuckGame/Tiles/HardLeft.cs
@@ -5,6 +5,8 @@
 // Assembly location: D:\Program Files (x86)\Steam\steamapps\common\Duck Game\DuckGame.exe
 // XML documentation location: D:\Program Files (x86)\Steam\steamapps\common\Duck Game\DuckGame.xml
 
+using System;
+
 namespace DuckGame
 {
     [EditorGroup("Details|Signs")]
@@ -23,6 +25,13 @@ namespace DuckGame
             depth = -0.5f;
             _editorName = "Hard Sign";
             hugWalls = WallHug.Floor;
+        }
+
+        public override Type TabRotate(bool control)
+        {
+            if (control)
+                return typeof(MallardBillboard);
+            return base.TabRotate(control);
         }
 
         public override void Draw()

--- a/DuckGame/src/DuckGame/Tiles/Lamp.cs
+++ b/DuckGame/src/DuckGame/Tiles/Lamp.cs
@@ -26,6 +26,7 @@ namespace DuckGame
             depth = (Depth)0.9f;
             hugWalls = WallHug.Floor;
             layer = Layer.Game;
+            editorCycleType = typeof(OfficeLight);
         }
 
         public override void Initialize()

--- a/DuckGame/src/DuckGame/Tiles/MallardBillboard.cs
+++ b/DuckGame/src/DuckGame/Tiles/MallardBillboard.cs
@@ -5,6 +5,8 @@
 // Assembly location: D:\Program Files (x86)\Steam\steamapps\common\Duck Game\DuckGame.exe
 // XML documentation location: D:\Program Files (x86)\Steam\steamapps\common\Duck Game\DuckGame.xml
 
+using System;
+
 namespace DuckGame
 {
     [EditorGroup("Details|Signs")]
@@ -25,6 +27,13 @@ namespace DuckGame
             _editorName = "Mallard Billboard";
             thickness = 0.2f;
             hugWalls = WallHug.Floor;
+        }
+
+        public override Type TabRotate(bool control)
+        {
+            if (control)
+                return typeof(ClippingSign);
+            return base.TabRotate(control);
         }
 
         public override void Initialize() => base.Initialize();

--- a/DuckGame/src/DuckGame/Tiles/OfficeLight.cs
+++ b/DuckGame/src/DuckGame/Tiles/OfficeLight.cs
@@ -26,6 +26,7 @@ namespace DuckGame
             depth = (Depth)0.9f;
             hugWalls = WallHug.Ceiling;
             layer = Layer.Game;
+            editorCycleType = typeof(StreetLight);
         }
 
         public override void Initialize()

--- a/DuckGame/src/DuckGame/Tiles/PineTrunkTileset.cs
+++ b/DuckGame/src/DuckGame/Tiles/PineTrunkTileset.cs
@@ -5,6 +5,8 @@
 // Assembly location: D:\Program Files (x86)\Steam\steamapps\common\Duck Game\DuckGame.exe
 // XML documentation location: D:\Program Files (x86)\Steam\steamapps\common\Duck Game\DuckGame.xml
 
+using System;
+
 namespace DuckGame
 {
     [EditorGroup("Blocks|Snow")]
@@ -32,6 +34,13 @@ namespace DuckGame
                 Level.CheckPoint<PineTree>(x, y - 16f)?.KnockOffSnow(with.velocity, true);
             }
             OnSoftImpact(with, from);
+        }
+
+        public override Type TabRotate(bool control)
+        {
+            if (control)
+                return typeof(TreeTileset);
+            return null;
         }
     }
 }

--- a/DuckGame/src/DuckGame/Tiles/PyramidBLight.cs
+++ b/DuckGame/src/DuckGame/Tiles/PyramidBLight.cs
@@ -31,6 +31,7 @@ namespace DuckGame
             alpha = 0.7f;
             layer = Layer.Game;
             placementLayerOverride = Layer.Blocks;
+            editorCycleType = typeof(PyramidLightRoof);
         }
 
         public override void Initialize()

--- a/DuckGame/src/DuckGame/Tiles/PyramidLightRoof.cs
+++ b/DuckGame/src/DuckGame/Tiles/PyramidLightRoof.cs
@@ -29,6 +29,7 @@ namespace DuckGame
             depth = (Depth)0.9f;
             hugWalls = WallHug.Ceiling;
             layer = Layer.Game;
+            editorCycleType = typeof(PyramidWallLight);
         }
 
         public override void Initialize()

--- a/DuckGame/src/DuckGame/Tiles/PyramidWallLight.cs
+++ b/DuckGame/src/DuckGame/Tiles/PyramidWallLight.cs
@@ -34,6 +34,7 @@ namespace DuckGame
             layer = Layer.Game;
             placementLayerOverride = Layer.Blocks;
             hugWalls = WallHug.Left | WallHug.Right;
+            editorCycleType = typeof(PyramidBLight);
         }
 
         public override void Draw()

--- a/DuckGame/src/DuckGame/Tiles/RaceSign.cs
+++ b/DuckGame/src/DuckGame/Tiles/RaceSign.cs
@@ -5,6 +5,8 @@
 // Assembly location: D:\Program Files (x86)\Steam\steamapps\common\Duck Game\DuckGame.exe
 // XML documentation location: D:\Program Files (x86)\Steam\steamapps\common\Duck Game\DuckGame.xml
 
+using System;
+
 namespace DuckGame
 {
     [EditorGroup("Details|Signs")]
@@ -23,6 +25,13 @@ namespace DuckGame
             depth = -0.5f;
             _editorName = "Race Sign";
             hugWalls = WallHug.Floor;
+        }
+
+        public override Type TabRotate(bool control)
+        {
+            if (control)
+                return typeof(UpSign);
+            return base.TabRotate(control);
         }
 
         public override void Draw()

--- a/DuckGame/src/DuckGame/Tiles/ScaffoldingTileset.cs
+++ b/DuckGame/src/DuckGame/Tiles/ScaffoldingTileset.cs
@@ -20,6 +20,7 @@ namespace DuckGame
             verticalWidthThick = 15f;
             horizontalHeight = 8f;
             _collideBottom = true;
+            editorCycleType = typeof(WoodScaffoldingTileset);
         }
     }
 }

--- a/DuckGame/src/DuckGame/Tiles/StreetLight.cs
+++ b/DuckGame/src/DuckGame/Tiles/StreetLight.cs
@@ -26,6 +26,7 @@ namespace DuckGame
             depth = (Depth)0.9f;
             hugWalls = WallHug.Floor;
             layer = Layer.Game;
+            editorCycleType = typeof(Sun);
         }
 
         public override void Initialize()

--- a/DuckGame/src/DuckGame/Tiles/Sun.cs
+++ b/DuckGame/src/DuckGame/Tiles/Sun.cs
@@ -21,6 +21,7 @@ namespace DuckGame
             depth = (Depth)0.9f;
             hugWalls = WallHug.Ceiling;
             layer = Layer.Game;
+            editorCycleType = typeof(TroubleLight);
         }
 
         public override void Initialize()

--- a/DuckGame/src/DuckGame/Tiles/TreeTileset.cs
+++ b/DuckGame/src/DuckGame/Tiles/TreeTileset.cs
@@ -5,6 +5,8 @@
 // Assembly location: D:\Program Files (x86)\Steam\steamapps\common\Duck Game\DuckGame.exe
 // XML documentation location: D:\Program Files (x86)\Steam\steamapps\common\Duck Game\DuckGame.xml
 
+using System;
+
 namespace DuckGame
 {
     [EditorGroup("Blocks|Jump Through")]
@@ -24,5 +26,14 @@ namespace DuckGame
             placementLayerOverride = Layer.Blocks;
             treeLike = true;
         }
+
+        public override Type TabRotate(bool control)
+        {
+            if (control)
+                return typeof(PineTrunkTileset);
+            else
+                return typeof(ScaffoldingTileset);
+        }
+
     }
 }

--- a/DuckGame/src/DuckGame/Tiles/TroubleLight.cs
+++ b/DuckGame/src/DuckGame/Tiles/TroubleLight.cs
@@ -26,6 +26,7 @@ namespace DuckGame
             depth = (Depth)0.9f;
             hugWalls = WallHug.Floor;
             layer = Layer.Game;
+            editorCycleType = typeof(Bulb);
         }
 
         public override void Initialize()

--- a/DuckGame/src/DuckGame/Tiles/TutorialGunCrouchJump.cs
+++ b/DuckGame/src/DuckGame/Tiles/TutorialGunCrouchJump.cs
@@ -13,6 +13,7 @@ namespace DuckGame
         public TutorialGunCrouchJump(float xpos, float ypos)
           : base(xpos, ypos, "tutorial/guncrouchjump", "Gun Crouch Jump")
         {
+            editorCycleType = typeof(TutorialGunJump);
         }
 
         public override void Draw()

--- a/DuckGame/src/DuckGame/Tiles/TutorialGunJump.cs
+++ b/DuckGame/src/DuckGame/Tiles/TutorialGunJump.cs
@@ -13,6 +13,7 @@ namespace DuckGame
         public TutorialGunJump(float xpos, float ypos)
           : base(xpos, ypos, "tutorial/gunjump", "Gun Jump")
         {
+            editorCycleType = typeof(TutorialSign00);
         }
 
         public override void Draw()

--- a/DuckGame/src/DuckGame/Tiles/TutorialSign00.cs
+++ b/DuckGame/src/DuckGame/Tiles/TutorialSign00.cs
@@ -13,6 +13,7 @@ namespace DuckGame
         public TutorialSign00(float xpos, float ypos)
           : base(xpos, ypos, "tutorial/jump", "Jump")
         {
+            editorCycleType = typeof(TutorialSign03);
         }
 
         public override void Draw()

--- a/DuckGame/src/DuckGame/Tiles/TutorialSign01.cs
+++ b/DuckGame/src/DuckGame/Tiles/TutorialSign01.cs
@@ -13,6 +13,7 @@ namespace DuckGame
         public TutorialSign01(float xpos, float ypos)
           : base(xpos, ypos, "tutorial/groundPound", "Ground Pound")
         {
+            editorCycleType = typeof(TutorialGunCrouchJump);
         }
 
         public override void Draw()

--- a/DuckGame/src/DuckGame/Tiles/TutorialSign02.cs
+++ b/DuckGame/src/DuckGame/Tiles/TutorialSign02.cs
@@ -13,6 +13,7 @@ namespace DuckGame
         public TutorialSign02(float xpos, float ypos)
           : base(xpos, ypos, "tutorial/slideUnder", "Slide Under")
         {
+            editorCycleType = typeof(TutorialSign04);
         }
 
         public override void Draw()

--- a/DuckGame/src/DuckGame/Tiles/TutorialSign03.cs
+++ b/DuckGame/src/DuckGame/Tiles/TutorialSign03.cs
@@ -13,6 +13,7 @@ namespace DuckGame
         public TutorialSign03(float xpos, float ypos)
           : base(xpos, ypos, "tutorial/jumpThrough", "Jump Through")
         {
+            editorCycleType = typeof(TutorialSign02);
         }
 
         public override void Draw()

--- a/DuckGame/src/DuckGame/Tiles/TutorialSign04.cs
+++ b/DuckGame/src/DuckGame/Tiles/TutorialSign04.cs
@@ -13,6 +13,7 @@ namespace DuckGame
         public TutorialSign04(float xpos, float ypos)
           : base(xpos, ypos, "tutorial/fallThrough", "Fall Through")
         {
+            editorCycleType = typeof(TutorialSign05);
         }
 
         public override void Draw()

--- a/DuckGame/src/DuckGame/Tiles/TutorialSign05.cs
+++ b/DuckGame/src/DuckGame/Tiles/TutorialSign05.cs
@@ -13,6 +13,7 @@ namespace DuckGame
         public TutorialSign05(float xpos, float ypos)
           : base(xpos, ypos, "tutorial/fly", "Fly")
         {
+            editorCycleType = typeof(TutorialSign01);
         }
 
         public override void Draw()

--- a/DuckGame/src/DuckGame/Tiles/UpSign.cs
+++ b/DuckGame/src/DuckGame/Tiles/UpSign.cs
@@ -5,6 +5,8 @@
 // Assembly location: D:\Program Files (x86)\Steam\steamapps\common\Duck Game\DuckGame.exe
 // XML documentation location: D:\Program Files (x86)\Steam\steamapps\common\Duck Game\DuckGame.xml
 
+using System;
+
 namespace DuckGame
 {
     [EditorGroup("Details|Signs")]
@@ -23,6 +25,13 @@ namespace DuckGame
             depth = -0.5f;
             _editorName = "Up Sign";
             hugWalls = WallHug.Floor;
+        }
+
+        public override Type TabRotate(bool control)
+        {
+            if (control)
+                return typeof(VeryHardSign);
+            return base.TabRotate(control);
         }
 
         public override void Draw()

--- a/DuckGame/src/DuckGame/Tiles/VeryHardSign.cs
+++ b/DuckGame/src/DuckGame/Tiles/VeryHardSign.cs
@@ -5,6 +5,8 @@
 // Assembly location: D:\Program Files (x86)\Steam\steamapps\common\Duck Game\DuckGame.exe
 // XML documentation location: D:\Program Files (x86)\Steam\steamapps\common\Duck Game\DuckGame.xml
 
+using System;
+
 namespace DuckGame
 {
     [EditorGroup("Details|Signs")]
@@ -23,6 +25,13 @@ namespace DuckGame
             depth = -0.5f;
             _editorName = "Very Hard Sign";
             hugWalls = WallHug.Floor;
+        }
+
+        public override Type TabRotate(bool control)
+        {
+            if (control)
+                return typeof(ArrowSign);
+            return base.TabRotate(control);
         }
 
         public override void Draw()

--- a/DuckGame/src/DuckGame/Tiles/WoodScaffoldingTileset.cs
+++ b/DuckGame/src/DuckGame/Tiles/WoodScaffoldingTileset.cs
@@ -20,6 +20,7 @@ namespace DuckGame
             horizontalHeight = 8f;
             _hasNubs = false;
             _collideBottom = true;
+            editorCycleType = typeof(TreeTileset);
         }
     }
 }

--- a/DuckGame/src/MonoTime/LevelEditor/Editor.cs
+++ b/DuckGame/src/MonoTime/LevelEditor/Editor.cs
@@ -2141,6 +2141,13 @@ namespace DuckGame
                                                           _placementType.editorCycleType != null;
                                             if (_input.Pressed(Triggers.RightStick) || Keyboard.Pressed(Keys.Tab))
                                             {
+                                                Thing thing = _eyeDropperSerialized != null
+                                                ? Thing.LoadThing(_eyeDropperSerialized)
+                                                : CreateThing(_placementType.GetType());
+                                                if (Keyboard.control)
+                                                    _placementType.editorCycleType = thing.TabRotate(true);
+                                                else
+                                                    _placementType.editorCycleType = thing.TabRotate(false);
                                                 if (_placementType.editorCycleType != null)
                                                 {
                                                     _placementType =
@@ -2149,10 +2156,6 @@ namespace DuckGame
                                                 }
                                                 else
                                                 {
-                                                    Thing thing = _eyeDropperSerialized != null
-                                                        ? Thing.LoadThing(_eyeDropperSerialized)
-                                                        : CreateThing(_placementType.GetType());
-                                                    thing.TabRotate();
                                                     _placementType = thing;
                                                     _eyeDropperSerialized = thing.Serialize();
                                                 }


### PR DESCRIPTION
This PR implements tab to cycle related entity (red pipe -> green pipe). And also control+tab for other useful functions (pipe background flag gets checked) (also entity cycling on entities that already have a function on tab).

- Parallax Background cycling on tab
- Item box cycling on tab
- Camera type cycling on tab
- Goody type cycling on tab
- Fun beam cycling on tab (vertical -><- horizontal)
- Pipe color cycling on tab
- Pipe background property changing on control+tab
- StandingFluid fluid type changing on tab
- Window type changing on tab (vertical -><- horizontal)
- Window bars property changing on control+tab
- Sign type cycling on control+tab
- Tutorial sign type cycling on tab
- Light type cycling on tab
- Pyramid light type cycling on tab
- Scaffolding type cycling on tab
- Tree scaffolding type cycling on tab+control (normal tree scaffolding -><- pine tree scaffolding)

https://streamable.com/pw6in6