### PR TITLE
Add "DisableMoreInEditor" option

### DIFF
--- a/DuckGame/AddedContent/DGRSettings.cs
+++ b/DuckGame/AddedContent/DGRSettings.cs
@@ -457,6 +457,7 @@ namespace DuckGame
         [Marker.AutoConfig] public static int RebuiltEffect = 1;
 
         [Marker.AutoConfig] public static bool StickyHats { get; set; }
+        [Marker.AutoConfig] public static bool DisableMoreInEditor { get; set; }
 
         [Marker.AutoConfig] public static bool QOLScoreThingButWithoutScore { get; set; } //why. -NiK0
 

--- a/DuckGame/src/MonoTime/LevelEditor/EditorGroup.cs
+++ b/DuckGame/src/MonoTime/LevelEditor/EditorGroup.cs
@@ -95,7 +95,7 @@ namespace DuckGame
             foreach (EditorGroup subGroup in SubGroups)
                 subGroup.Sort();
             int index1 = 12;
-            if (SubGroups.Count <= index1 || !rootGroup)
+            if (SubGroups.Count <= index1 || !rootGroup || DGRSettings.DisableMoreInEditor)
                 return;
             EditorGroup editorGroup = new EditorGroup
             {

--- a/DuckGame/src/MonoTime/LevelEditor/EditorGroupMenu.cs
+++ b/DuckGame/src/MonoTime/LevelEditor/EditorGroupMenu.cs
@@ -17,7 +17,7 @@ namespace DuckGame
             _root = root;
             if (!_root)
                 greyOut = Editor._currentLevelData.metaData.onlineMode; //Main.isDemo || 
-            _maxNumToDraw = 20;
+            _maxNumToDraw = DGRSettings.DisableMoreInEditor ? 17 : 20;
         }
 
         public override void Update()
@@ -25,7 +25,7 @@ namespace DuckGame
             if (Editor.bigInterfaceMode)
                 _maxNumToDraw = 13;
             else
-                _maxNumToDraw = 20;
+                _maxNumToDraw = DGRSettings.DisableMoreInEditor ? 17 : 20;
             base.Update();
         }
 

--- a/DuckGame/src/MonoTime/Options.cs
+++ b/DuckGame/src/MonoTime/Options.cs
@@ -653,6 +653,10 @@ namespace DuckGame
             {
                 dgrDescription = "Uses DGR's custom DuckShell language to run commands in the console, which provides more power-user and automation features"
             });
+            menu.Add(new UIMenuItemToggle("Disable \"More...\"", field: new FieldBinding(typeof(DGRSettings), nameof(DGRSettings.DisableMoreInEditor)))
+            {
+                dgrDescription = "Shows all menus at once, instead of having \"More...\" menu in editor (REQUIRES RESTART)"
+            });
 
             menu.Add(new UIText(" ", Color.White));
             menu.Add(new UIMenuItem("BACK", new UIMenuActionOpenMenu(menu, pPrev), backButton: true));


### PR DESCRIPTION
I don't like that when I have many mods enabled some of them are separated in another menu (without reason)
This PR adds option to disable that, so root menu has all mods.
_maxNumToDraw is change if that option is on, because otherwise you can't quit editor, because quit and "scroll down" buttons overlap.