### PR TITLE
Fix "source" command Scripts path

### DIFF
--- a/DuckGame/AddedContent/Firebreak/DuckShell/Console/Commands/Source.cs
+++ b/DuckGame/AddedContent/Firebreak/DuckShell/Console/Commands/Source.cs
@@ -7,13 +7,13 @@ namespace DuckGame.ConsoleEngine
 {
     public static partial class Commands
     {
-        public static string ScriptsDirPath => $"{DuckFile.saveDirectory}DuckGame/Scripts/";
+        public static string ScriptsDirPath => $"{DuckFile.saveDirectory}Scripts/";
         public const string SCRIPT_FILE_EXTENSION = ".dsh";
         
         [Marker.DevConsoleCommand(Description = "Runs a script from your ~DuckGame/Scripts/ folder", To = ImplementTo.DuckShell)]
         public static void Source(
             [FilePathAutoCompl(
-                "|saveDirectory|DuckGame/Scripts",
+                "|saveDirectory|Scripts",
                 SystemEntryType.File,
                 SearchOption.TopDirectoryOnly, // todo: support recursive directory search
                 FilePathAutoComplAttribute.Return.EntryNameNoExtension)] string scriptName)


### PR DESCRIPTION
Before it looked in `DuckGame/DuckGame/Scripts`, this pr fixes that.