### PR TITLE
Add "ReplaceRegex" DSH command

### DIFF
--- a/DuckGame/AddedContent/Firebreak/DuckShell/Console/Commands/ReplaceRegex.cs
+++ b/DuckGame/AddedContent/Firebreak/DuckShell/Console/Commands/ReplaceRegex.cs
@@ -1,0 +1,14 @@
+﻿using AddedContent.Firebreak;
+using System.Text.RegularExpressions;
+
+namespace DuckGame.ConsoleEngine
+{
+    public static partial class Commands
+    {
+        [Marker.DevConsoleCommand(Name = "replaceregex", Description = "Replace using regex. \nKeep in mind that you need to backslash backslashes", To = ImplementTo.DuckShell)]
+        public static string ReplaceRegex(string givenString, string pattern, string to)
+        {
+            return Regex.Replace(givenString, pattern, to);
+        }
+    }
+}

--- a/DuckGame/DuckGame.csproj
+++ b/DuckGame/DuckGame.csproj
@@ -353,6 +353,7 @@
     <Compile Include="AddedContent\Firebreak\DuckShell\Console\Commands\DrawStringOutline.cs" />
     <Compile Include="AddedContent\Firebreak\DuckShell\Console\Commands\ExecLegacy.cs" />
     <Compile Include="AddedContent\Firebreak\DuckShell\Console\Commands\Queue.cs" />
+    <Compile Include="AddedContent\Firebreak\DuckShell\Console\Commands\ReplaceRegex.cs" />
     <Compile Include="AddedContent\Firebreak\DuckShell\Console\Commands\RNG.cs" />
     <Compile Include="AddedContent\Firebreak\DuckShell\Console\Commands\Wait.cs" />
     <Compile Include="AddedContent\Firebreak\DuckShell\Engine\AutoCompletionTags\AutoCompl.cs" />


### PR DESCRIPTION
Useful for `source` to have "macros"
For example, `\$([^ \n\r])+` regex replaces `$var` with `{get var}`, which gives cleaner code.