### PR TITLE
Fix CMD -> DSH conversion, and add option to disable it

### DIFF
--- a/DuckGame/AddedContent/DGRSettings.cs
+++ b/DuckGame/AddedContent/DGRSettings.cs
@@ -459,6 +459,8 @@ namespace DuckGame
         [Marker.AutoConfig] public static bool StickyHats { get; set; }
         [Marker.AutoConfig] public static bool DisableMoreInEditor { get; set; }
 
+        [Marker.AutoConfig] public static bool ConvertModdedCommands = true;
+
 
         private static bool _useEnabledModsConfig = false;
         [Marker.AutoConfig] public static bool UseEnabledModsConfig { get => _useEnabledModsConfig; set {

--- a/DuckGame/src/MonoTime/Console/DevConsole.cs
+++ b/DuckGame/src/MonoTime/Console/DevConsole.cs
@@ -607,7 +607,7 @@ namespace DuckGame
                         GetCommands(alias).Add(pCommand);
                 }
 
-                if (pCommand.noDsh)
+                if (pCommand.noDsh || !DGRSettings.ConvertModdedCommands)
                     return;
 
                 // support DSH too

--- a/DuckGame/src/MonoTime/Console/DevConsole.cs
+++ b/DuckGame/src/MonoTime/Console/DevConsole.cs
@@ -597,52 +597,73 @@ namespace DuckGame
 
         public static void AddCommand(CMD pCommand)
         {
-            GetCommands(pCommand.keyword).Add(pCommand);
-            
-            if (pCommand.aliases != null)
+            try
             {
-                foreach (string alias in pCommand.aliases)
-                    GetCommands(alias).Add(pCommand);
-            }
+                GetCommands(pCommand.keyword).Add(pCommand);
 
-            if (pCommand.noDsh)
-                return;
-            
-            // support DSH too
-            CMD.Argument[] arguments = pCommand.arguments;
-            ShellCommand.Parameter[] parameters = new ShellCommand.Parameter[arguments.Length];
+                if (pCommand.aliases != null)
+                {
+                    foreach (string alias in pCommand.aliases)
+                        GetCommands(alias).Add(pCommand);
+                }
 
-            for (int i = 0; i < arguments.Length; i++)
-            {
-                CMD.Argument argument = arguments[i];
-            
-                parameters[i] = new ShellCommand.Parameter()
+                if (pCommand.noDsh)
+                    return;
+
+                // support DSH too
+                ShellCommand shellCommand;
+
+                if (pCommand.arguments != null)
                 {
-                    Name = argument.name ?? "<NULL>",
-                    ParameterType = argument.type,
-                    IsOptional = argument.optional,
-                    DefaultValue = argument.defaultValue
-                };
-            }
-            
-            ShellCommand shellCommand = new(pCommand.keyword, parameters, args =>
-            {
-                for (int i = 0; i < pCommand.arguments.Length; i++)
+                    CMD.Argument[] arguments = pCommand.arguments;
+                    ShellCommand.Parameter[] parameters = new ShellCommand.Parameter[arguments.Length];
+
+                    for (int i = 0; i < arguments.Length; i++)
+                    {
+                        CMD.Argument argument = arguments[i];
+
+                        parameters[i] = new ShellCommand.Parameter()
+                        {
+                            Name = argument.name ?? "<NULL>",
+                            ParameterType = argument.type,
+                            IsOptional = argument.optional,
+                            DefaultValue = argument.defaultValue
+                        };
+                    }
+
+                    shellCommand = new(pCommand.keyword, parameters, args =>
+                    {
+                        for (int i = 0; i < pCommand.arguments.Length; i++)
+                        {
+                            pCommand.arguments[i].value = args[i];
+                        }
+
+                        pCommand.action(pCommand);
+                        return null;
+                    });
+                } else
                 {
-                    pCommand.arguments[i].value = args[i];
+                    shellCommand = new(pCommand.keyword, null, args =>
+                    {
+                        pCommand.alternateAction();
+                        
+                        return null;
+                    });
                 }
                 
-                pCommand.action(pCommand);
-                return null;
-            });
 
-            DevConsoleDSHWrapper.AttributeCommands.Add(new Marker.DevConsoleCommandAttribute()
+                DevConsoleDSHWrapper.AttributeCommands.Add(new Marker.DevConsoleCommandAttribute()
+                {
+                    Name = pCommand.keyword,
+                    Description = pCommand.description,
+                    IsCheat = pCommand.cheat,
+                    Command = shellCommand
+                });
+            } catch (Exception e)
             {
-                Name = pCommand.keyword,
-                Description = pCommand.description,
-                IsCheat = pCommand.cheat,
-                Command = shellCommand
-            });
+                DevConsole.Log(e);
+            }
+            
         }
 
         public static List<CMD> GetCommands(string pKeyword)

--- a/DuckGame/src/MonoTime/Options.cs
+++ b/DuckGame/src/MonoTime/Options.cs
@@ -658,6 +658,11 @@ namespace DuckGame
                 dgrDescription = "Uses DGR's custom DuckShell language to run commands in the console, which provides more power-user and automation features"
             });
 
+            menu.Add(new UIMenuItemToggle("Convert commands", field: new FieldBinding(typeof(DGRSettings), nameof(DGRSettings.ConvertModdedCommands)))
+            {
+                dgrDescription = "Game tries to add CMD commands from mods to DuckShell\n(REQUIRES RESTART)"
+            });
+
             menu.Add(new UIMenuItemToggle("Use <Enabled>", field: new FieldBinding(typeof(DGRSettings), nameof(DGRSettings.UseEnabledModsConfig)))
             {
                 dgrDescription = "Uses <Enabled> from mod's config\n instead of <Disabled>, which allows to have presets"


### PR DESCRIPTION
Fix code which tried to convert CMD commands to duck shell commands, and add option to disable that conversion.
Issue with conversion was "null reference exception" when CMD arguments are null.