### PR TITLE
Wire Tab+Control Entity Type Switching, Trapdoor not updating fix, and variable naming

### DIFF
--- a/DuckGame/src/DuckGame/Levels/ArmatureLogo.cs
+++ b/DuckGame/src/DuckGame/Levels/ArmatureLogo.cs
@@ -1,11 +1,4 @@
-﻿//// Decompiled with JetBrains decompiler
-//// Type: DuckGame.ArmatureLogo
-////removed for regex reasons Culture=neutral, PublicKeyToken=null
-//// MVID: C907F20B-C12B-4773-9B1E-25290117C0E4
-//// Assembly location: D:\Program Files (x86)\Steam\steamapps\common\Duck Game\DuckGame.exe
-//// XML documentation location: D:\Program Files (x86)\Steam\steamapps\common\Duck Game\DuckGame.xml
-
-//namespace DuckGame
+﻿//namespace DuckGame
 //{
 //    public class ArmatureLogo : Level
 //    {

--- a/DuckGame/src/DuckGame/Levels/BetaScreen.cs
+++ b/DuckGame/src/DuckGame/Levels/BetaScreen.cs
@@ -1,11 +1,4 @@
-﻿//// Decompiled with JetBrains decompiler
-//// Type: DuckGame.BetaScreen
-////removed for regex reasons Culture=neutral, PublicKeyToken=null
-//// MVID: C907F20B-C12B-4773-9B1E-25290117C0E4
-//// Assembly location: D:\Program Files (x86)\Steam\steamapps\common\Duck Game\DuckGame.exe
-//// XML documentation location: D:\Program Files (x86)\Steam\steamapps\common\Duck Game\DuckGame.xml
-
-//namespace DuckGame
+﻿//namespace DuckGame
 //{
 //    public class BetaScreen : Level
 //    {

--- a/DuckGame/src/DuckGame/Levels/BuyScreen.cs
+++ b/DuckGame/src/DuckGame/Levels/BuyScreen.cs
@@ -1,11 +1,4 @@
-﻿//// Decompiled with JetBrains decompiler
-//// Type: DuckGame.BuyScreen
-////removed for regex reasons Culture=neutral, PublicKeyToken=null
-//// MVID: C907F20B-C12B-4773-9B1E-25290117C0E4
-//// Assembly location: D:\Program Files (x86)\Steam\steamapps\common\Duck Game\DuckGame.exe
-//// XML documentation location: D:\Program Files (x86)\Steam\steamapps\common\Duck Game\DuckGame.xml
-
-//using System;
+﻿//using System;
 //using System.Globalization;
 
 //namespace DuckGame

--- a/DuckGame/src/DuckGame/Levels/Challenge/PrizeTable.cs
+++ b/DuckGame/src/DuckGame/Levels/Challenge/PrizeTable.cs
@@ -1,11 +1,4 @@
-﻿// Decompiled with JetBrains decompiler
-// Type: DuckGame.PrizeTable
-//removed for regex reasons Culture=neutral, PublicKeyToken=null
-// MVID: C907F20B-C12B-4773-9B1E-25290117C0E4
-// Assembly location: D:\Program Files (x86)\Steam\steamapps\common\Duck Game\DuckGame.exe
-// XML documentation location: D:\Program Files (x86)\Steam\steamapps\common\Duck Game\DuckGame.xml
-
-using static DuckGame.CMD;
+﻿using static DuckGame.CMD;
 
 namespace DuckGame
 {

--- a/DuckGame/src/DuckGame/Levels/CrashLogRoom.cs
+++ b/DuckGame/src/DuckGame/Levels/CrashLogRoom.cs
@@ -1,11 +1,4 @@
-﻿//// Decompiled with JetBrains decompiler
-//// Type: DuckGame.CrashLogRoom
-////removed for regex reasons Culture=neutral, PublicKeyToken=null
-//// MVID: C907F20B-C12B-4773-9B1E-25290117C0E4
-//// Assembly location: D:\Program Files (x86)\Steam\steamapps\common\Duck Game\DuckGame.exe
-//// XML documentation location: D:\Program Files (x86)\Steam\steamapps\common\Duck Game\DuckGame.xml
-
-//namespace DuckGame
+﻿//namespace DuckGame
 //{
 //    internal class CrashLogRoom : Level
 //    {

--- a/DuckGame/src/DuckGame/Levels/Deathmatch/GinormoBoard.cs
+++ b/DuckGame/src/DuckGame/Levels/Deathmatch/GinormoBoard.cs
@@ -1,11 +1,4 @@
-﻿// Decompiled with JetBrains decompiler
-// Type: DuckGame.GinormoBoard
-//removed for regex reasons Culture=neutral, PublicKeyToken=null
-// MVID: C907F20B-C12B-4773-9B1E-25290117C0E4
-// Assembly location: D:\Program Files (x86)\Steam\steamapps\common\Duck Game\DuckGame.exe
-// XML documentation location: D:\Program Files (x86)\Steam\steamapps\common\Duck Game\DuckGame.xml
-
-using Microsoft.Xna.Framework.Graphics;
+﻿using Microsoft.Xna.Framework.Graphics;
 
 namespace DuckGame
 {

--- a/DuckGame/src/DuckGame/Levels/Deathmatch/GinormoCard.cs
+++ b/DuckGame/src/DuckGame/Levels/Deathmatch/GinormoCard.cs
@@ -1,11 +1,4 @@
-﻿// Decompiled with JetBrains decompiler
-// Type: DuckGame.GinormoCard
-//removed for regex reasons Culture=neutral, PublicKeyToken=null
-// MVID: C907F20B-C12B-4773-9B1E-25290117C0E4
-// Assembly location: D:\Program Files (x86)\Steam\steamapps\common\Duck Game\DuckGame.exe
-// XML documentation location: D:\Program Files (x86)\Steam\steamapps\common\Duck Game\DuckGame.xml
-
-using Microsoft.Xna.Framework.Graphics;
+﻿using Microsoft.Xna.Framework.Graphics;
 using System.Collections.Generic;
 
 namespace DuckGame

--- a/DuckGame/src/DuckGame/Levels/Deathmatch/RainParticle.cs
+++ b/DuckGame/src/DuckGame/Levels/Deathmatch/RainParticle.cs
@@ -1,11 +1,4 @@
-﻿// Decompiled with JetBrains decompiler
-// Type: DuckGame.RainParticle
-//removed for regex reasons Culture=neutral, PublicKeyToken=null
-// MVID: C907F20B-C12B-4773-9B1E-25290117C0E4
-// Assembly location: D:\Program Files (x86)\Steam\steamapps\common\Duck Game\DuckGame.exe
-// XML documentation location: D:\Program Files (x86)\Steam\steamapps\common\Duck Game\DuckGame.xml
-
-using Microsoft.Xna.Framework;
+﻿using Microsoft.Xna.Framework;
 using Microsoft.Xna.Framework.Graphics;
 
 namespace DuckGame

--- a/DuckGame/src/DuckGame/Levels/Doodleroom.cs
+++ b/DuckGame/src/DuckGame/Levels/Doodleroom.cs
@@ -1,11 +1,4 @@
-﻿//// Decompiled with JetBrains decompiler
-//// Type: DuckGame.Doodleroom
-////removed for regex reasons Culture=neutral, PublicKeyToken=null
-//// MVID: C907F20B-C12B-4773-9B1E-25290117C0E4
-//// Assembly location: D:\Program Files (x86)\Steam\steamapps\common\Duck Game\DuckGame.exe
-//// XML documentation location: D:\Program Files (x86)\Steam\steamapps\common\Duck Game\DuckGame.xml
-
-//using Microsoft.Xna.Framework.Graphics;
+﻿//using Microsoft.Xna.Framework.Graphics;
 
 //namespace DuckGame
 //{

--- a/DuckGame/src/DuckGame/Levels/LevelSelect/LSItem.cs
+++ b/DuckGame/src/DuckGame/Levels/LevelSelect/LSItem.cs
@@ -1,11 +1,4 @@
-﻿// Decompiled with JetBrains decompiler
-// Type: DuckGame.LSItem
-//removed for regex reasons Culture=neutral, PublicKeyToken=null
-// MVID: C907F20B-C12B-4773-9B1E-25290117C0E4
-// Assembly location: D:\Program Files (x86)\Steam\steamapps\common\Duck Game\DuckGame.exe
-// XML documentation location: D:\Program Files (x86)\Steam\steamapps\common\Duck Game\DuckGame.xml
-
-using System;
+﻿using System;
 using System.IO;
 using System.Linq;
 using System.Collections.Generic;

--- a/DuckGame/src/DuckGame/Levels/LevelSelect/LevelSelect.cs
+++ b/DuckGame/src/DuckGame/Levels/LevelSelect/LevelSelect.cs
@@ -1,11 +1,4 @@
-﻿// Decompiled with JetBrains decompiler
-// Type: DuckGame.LevelSelect
-//removed for regex reasons Culture=neutral, PublicKeyToken=null
-// MVID: C907F20B-C12B-4773-9B1E-25290117C0E4
-// Assembly location: D:\Program Files (x86)\Steam\steamapps\common\Duck Game\DuckGame.exe
-// XML documentation location: D:\Program Files (x86)\Steam\steamapps\common\Duck Game\DuckGame.xml
-
-using Microsoft.Xna.Framework.Graphics;
+﻿using Microsoft.Xna.Framework.Graphics;
 using System;
 using System.Collections.Generic;
 using System.IO;

--- a/DuckGame/src/DuckGame/Levels/SuperTestRoom.cs
+++ b/DuckGame/src/DuckGame/Levels/SuperTestRoom.cs
@@ -1,11 +1,4 @@
-﻿//// Decompiled with JetBrains decompiler
-//// Type: DuckGame.SuperTestRoom
-////removed for regex reasons Culture=neutral, PublicKeyToken=null
-//// MVID: C907F20B-C12B-4773-9B1E-25290117C0E4
-//// Assembly location: D:\Program Files (x86)\Steam\steamapps\common\Duck Game\DuckGame.exe
-//// XML documentation location: D:\Program Files (x86)\Steam\steamapps\common\Duck Game\DuckGame.xml
-
-//namespace DuckGame
+﻿//namespace DuckGame
 //{
 //    public class SuperTestRoom : Level
 //    {

--- a/DuckGame/src/DuckGame/Levels/Tournament.cs
+++ b/DuckGame/src/DuckGame/Levels/Tournament.cs
@@ -1,11 +1,4 @@
-﻿//// Decompiled with JetBrains decompiler
-//// Type: DuckGame.Tournament
-////removed for regex reasons Culture=neutral, PublicKeyToken=null
-//// MVID: C907F20B-C12B-4773-9B1E-25290117C0E4
-//// Assembly location: D:\Program Files (x86)\Steam\steamapps\common\Duck Game\DuckGame.exe
-//// XML documentation location: D:\Program Files (x86)\Steam\steamapps\common\Duck Game\DuckGame.xml
-
-//using System;
+﻿//using System;
 //using System.Collections.Generic;
 
 //namespace DuckGame

--- a/DuckGame/src/DuckGame/Levels/TourneyGroup.cs
+++ b/DuckGame/src/DuckGame/Levels/TourneyGroup.cs
@@ -1,11 +1,4 @@
-﻿//// Decompiled with JetBrains decompiler
-//// Type: DuckGame.TourneyGroup
-////removed for regex reasons Culture=neutral, PublicKeyToken=null
-//// MVID: C907F20B-C12B-4773-9B1E-25290117C0E4
-//// Assembly location: D:\Program Files (x86)\Steam\steamapps\common\Duck Game\DuckGame.exe
-//// XML documentation location: D:\Program Files (x86)\Steam\steamapps\common\Duck Game\DuckGame.xml
-
-//using System.Collections.Generic;
+﻿//using System.Collections.Generic;
 
 //namespace DuckGame
 //{

--- a/DuckGame/src/DuckGame/Levels/WeaponBrowser/WeaponBrowser.cs
+++ b/DuckGame/src/DuckGame/Levels/WeaponBrowser/WeaponBrowser.cs
@@ -1,11 +1,4 @@
-﻿//// Decompiled with JetBrains decompiler
-//// Type: DuckGame.WeaponBrowser
-////removed for regex reasons Culture=neutral, PublicKeyToken=null
-//// MVID: C907F20B-C12B-4773-9B1E-25290117C0E4
-//// Assembly location: D:\Program Files (x86)\Steam\steamapps\common\Duck Game\DuckGame.exe
-//// XML documentation location: D:\Program Files (x86)\Steam\steamapps\common\Duck Game\DuckGame.xml
-
-//namespace DuckGame
+﻿//namespace DuckGame
 //{
 //    public class WeaponBrowser : Level
 //    {

--- a/DuckGame/src/DuckGame/Levels/WeaponBrowser/WeaponInfoBox.cs
+++ b/DuckGame/src/DuckGame/Levels/WeaponBrowser/WeaponInfoBox.cs
@@ -1,11 +1,4 @@
-﻿//// Decompiled with JetBrains decompiler
-//// Type: DuckGame.WeaponInfoBox
-////removed for regex reasons Culture=neutral, PublicKeyToken=null
-//// MVID: C907F20B-C12B-4773-9B1E-25290117C0E4
-//// Assembly location: D:\Program Files (x86)\Steam\steamapps\common\Duck Game\DuckGame.exe
-//// XML documentation location: D:\Program Files (x86)\Steam\steamapps\common\Duck Game\DuckGame.xml
-
-//namespace DuckGame
+﻿//namespace DuckGame
 //{
 //    public class WeaponInfoBox : Thing
 //    {

--- a/DuckGame/src/DuckGame/Levels/WeaponTest.cs
+++ b/DuckGame/src/DuckGame/Levels/WeaponTest.cs
@@ -1,11 +1,4 @@
-﻿//// Decompiled with JetBrains decompiler
-//// Type: DuckGame.WeaponTest
-////removed for regex reasons Culture=neutral, PublicKeyToken=null
-//// MVID: C907F20B-C12B-4773-9B1E-25290117C0E4
-//// Assembly location: D:\Program Files (x86)\Steam\steamapps\common\Duck Game\DuckGame.exe
-//// XML documentation location: D:\Program Files (x86)\Steam\steamapps\common\Duck Game\DuckGame.xml
-
-//namespace DuckGame
+﻿//namespace DuckGame
 //{
 //    public class WeaponTest : DuckGameTestArea
 //    {

--- a/DuckGame/src/DuckGame/Network/DatablockManager.cs
+++ b/DuckGame/src/DuckGame/Network/DatablockManager.cs
@@ -1,11 +1,4 @@
-﻿//// Decompiled with JetBrains decompiler
-//// Type: DuckGame.DatablockManager
-////removed for regex reasons Culture=neutral, PublicKeyToken=null
-//// MVID: C907F20B-C12B-4773-9B1E-25290117C0E4
-//// Assembly location: D:\Program Files (x86)\Steam\steamapps\common\Duck Game\DuckGame.exe
-//// XML documentation location: D:\Program Files (x86)\Steam\steamapps\common\Duck Game\DuckGame.xml
-
-//namespace DuckGame
+﻿//namespace DuckGame
 //{
 //    public class DatablockManager
 //    {

--- a/DuckGame/src/DuckGame/Network/GhostConnectionData.cs
+++ b/DuckGame/src/DuckGame/Network/GhostConnectionData.cs
@@ -1,11 +1,4 @@
-﻿// Decompiled with JetBrains decompiler
-// Type: DuckGame.GhostConnectionData
-//removed for regex reasons Culture=neutral, PublicKeyToken=null
-// MVID: C907F20B-C12B-4773-9B1E-25290117C0E4
-// Assembly location: D:\Program Files (x86)\Steam\steamapps\common\Duck Game\DuckGame.exe
-// XML documentation location: D:\Program Files (x86)\Steam\steamapps\common\Duck Game\DuckGame.xml
-
-namespace DuckGame
+﻿namespace DuckGame
 {
     public class GhostConnectionData
     {

--- a/DuckGame/src/DuckGame/Network/NMExplodingProp.cs
+++ b/DuckGame/src/DuckGame/Network/NMExplodingProp.cs
@@ -1,11 +1,4 @@
-﻿// Decompiled with JetBrains decompiler
-// Type: DuckGame.NMExplodingProp
-//removed for regex reasons Culture=neutral, PublicKeyToken=null
-// MVID: C907F20B-C12B-4773-9B1E-25290117C0E4
-// Assembly location: D:\Program Files (x86)\Steam\steamapps\common\Duck Game\DuckGame.exe
-// XML documentation location: D:\Program Files (x86)\Steam\steamapps\common\Duck Game\DuckGame.xml
-
-using System;
+﻿using System;
 using System.Collections.Generic;
 
 namespace DuckGame

--- a/DuckGame/src/DuckGame/Network/NMGhostState.cs
+++ b/DuckGame/src/DuckGame/Network/NMGhostState.cs
@@ -1,11 +1,4 @@
-﻿// Decompiled with JetBrains decompiler
-// Type: DuckGame.NMGhostState
-//removed for regex reasons Culture=neutral, PublicKeyToken=null
-// MVID: C907F20B-C12B-4773-9B1E-25290117C0E4
-// Assembly location: D:\Program Files (x86)\Steam\steamapps\common\Duck Game\DuckGame.exe
-// XML documentation location: D:\Program Files (x86)\Steam\steamapps\common\Duck Game\DuckGame.xml
-
-namespace DuckGame
+﻿namespace DuckGame
 {
     public class NMGhostState : NetMessage
     {

--- a/DuckGame/src/DuckGame/ParentalConrols.cs
+++ b/DuckGame/src/DuckGame/ParentalConrols.cs
@@ -1,11 +1,4 @@
-﻿//// Decompiled with JetBrains decompiler
-//// Type: DuckGame.ParentalControls
-////removed for regex reasons Culture=neutral, PublicKeyToken=null
-//// MVID: C907F20B-C12B-4773-9B1E-25290117C0E4
-//// Assembly location: D:\Program Files (x86)\Steam\steamapps\common\Duck Game\DuckGame.exe
-//// XML documentation location: D:\Program Files (x86)\Steam\steamapps\common\Duck Game\DuckGame.xml
-
-//namespace DuckGame
+﻿//namespace DuckGame
 //{
 //    internal static class ParentalControls
 //    {

--- a/DuckGame/src/DuckGame/Particles/Explosion.cs
+++ b/DuckGame/src/DuckGame/Particles/Explosion.cs
@@ -1,11 +1,4 @@
-﻿// Decompiled with JetBrains decompiler
-// Type: DuckGame.ExplosionPart
-//removed for regex reasons Culture=neutral, PublicKeyToken=null
-// MVID: C907F20B-C12B-4773-9B1E-25290117C0E4
-// Assembly location: D:\Program Files (x86)\Steam\steamapps\common\Duck Game\DuckGame.exe
-// XML documentation location: D:\Program Files (x86)\Steam\steamapps\common\Duck Game\DuckGame.xml
-
-namespace DuckGame
+﻿namespace DuckGame
 {
     public class ExplosionPart : Thing
     {

--- a/DuckGame/src/DuckGame/Particles/MagnaLine.cs
+++ b/DuckGame/src/DuckGame/Particles/MagnaLine.cs
@@ -1,11 +1,4 @@
-﻿// Decompiled with JetBrains decompiler
-// Type: DuckGame.MagnaLine
-//removed for regex reasons Culture=neutral, PublicKeyToken=null
-// MVID: C907F20B-C12B-4773-9B1E-25290117C0E4
-// Assembly location: D:\Program Files (x86)\Steam\steamapps\common\Duck Game\DuckGame.exe
-// XML documentation location: D:\Program Files (x86)\Steam\steamapps\common\Duck Game\DuckGame.xml
-
-using System;
+﻿using System;
 
 namespace DuckGame
 {

--- a/DuckGame/src/DuckGame/Particles/MusketSmoke.cs
+++ b/DuckGame/src/DuckGame/Particles/MusketSmoke.cs
@@ -1,11 +1,4 @@
-﻿// Decompiled with JetBrains decompiler
-// Type: DuckGame.MusketSmoke
-//removed for regex reasons Culture=neutral, PublicKeyToken=null
-// MVID: C907F20B-C12B-4773-9B1E-25290117C0E4
-// Assembly location: D:\Program Files (x86)\Steam\steamapps\common\Duck Game\DuckGame.exe
-// XML documentation location: D:\Program Files (x86)\Steam\steamapps\common\Duck Game\DuckGame.xml
-
-namespace DuckGame
+﻿namespace DuckGame
 {
     public class MusketSmoke : Thing
     {

--- a/DuckGame/src/DuckGame/Particles/SmallSmoke.cs
+++ b/DuckGame/src/DuckGame/Particles/SmallSmoke.cs
@@ -1,11 +1,4 @@
-﻿// Decompiled with JetBrains decompiler
-// Type: DuckGame.SmallSmoke
-//removed for regex reasons Culture=neutral, PublicKeyToken=null
-// MVID: C907F20B-C12B-4773-9B1E-25290117C0E4
-// Assembly location: D:\Program Files (x86)\Steam\steamapps\common\Duck Game\DuckGame.exe
-// XML documentation location: D:\Program Files (x86)\Steam\steamapps\common\Duck Game\DuckGame.xml
-
-using System;
+﻿using System;
 using System.Diagnostics;
 
 namespace DuckGame

--- a/DuckGame/src/DuckGame/Particles/SnowFallParticle.cs
+++ b/DuckGame/src/DuckGame/Particles/SnowFallParticle.cs
@@ -1,5 +1,4 @@
-﻿// Decompiled with JetBrains decompiler
-using System;
+﻿using System;
 
 namespace DuckGame
 {

--- a/DuckGame/src/DuckGame/Particles/SpawnAimer.cs
+++ b/DuckGame/src/DuckGame/Particles/SpawnAimer.cs
@@ -1,11 +1,4 @@
-﻿// Decompiled with JetBrains decompiler
-// Type: DuckGame.SpawnAimer
-//removed for regex reasons Culture=neutral, PublicKeyToken=null
-// MVID: C907F20B-C12B-4773-9B1E-25290117C0E4
-// Assembly location: D:\Program Files (x86)\Steam\steamapps\common\Duck Game\DuckGame.exe
-// XML documentation location: D:\Program Files (x86)\Steam\steamapps\common\Duck Game\DuckGame.xml
-
-using System;
+﻿using System;
 using System.Collections.Generic;
 
 namespace DuckGame

--- a/DuckGame/src/DuckGame/PhysicsObject.cs
+++ b/DuckGame/src/DuckGame/PhysicsObject.cs
@@ -1,11 +1,4 @@
-﻿// Decompiled with JetBrains decompiler
-// Type: DuckGame.PhysicsObject
-//removed for regex reasons Culture=neutral, PublicKeyToken=null
-// MVID: C907F20B-C12B-4773-9B1E-25290117C0E4
-// Assembly location: D:\Program Files (x86)\Steam\steamapps\common\Duck Game\DuckGame.exe
-// XML documentation location: D:\Program Files (x86)\Steam\steamapps\common\Duck Game\DuckGame.xml
-
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;

--- a/DuckGame/src/DuckGame/Player.cs
+++ b/DuckGame/src/DuckGame/Player.cs
@@ -1,11 +1,4 @@
-﻿//// Decompiled with JetBrains decompiler
-//// Type: DuckGame.Player
-////removed for regex reasons Culture=neutral, PublicKeyToken=null
-//// MVID: C907F20B-C12B-4773-9B1E-25290117C0E4
-//// Assembly location: D:\Program Files (x86)\Steam\steamapps\common\Duck Game\DuckGame.exe
-//// XML documentation location: D:\Program Files (x86)\Steam\steamapps\common\Duck Game\DuckGame.xml
-
-//namespace DuckGame
+﻿//namespace DuckGame
 //{
 //    public static class Player
 //    {

--- a/DuckGame/src/DuckGame/SmartDuck/AIPathFinder.cs
+++ b/DuckGame/src/DuckGame/SmartDuck/AIPathFinder.cs
@@ -1,11 +1,4 @@
-﻿//// Decompiled with JetBrains decompiler
-//// Type: DuckGame.AIPathFinder
-////removed for regex reasons Culture=neutral, PublicKeyToken=null
-//// MVID: C907F20B-C12B-4773-9B1E-25290117C0E4
-//// Assembly location: D:\Program Files (x86)\Steam\steamapps\common\Duck Game\DuckGame.exe
-//// XML documentation location: D:\Program Files (x86)\Steam\steamapps\common\Duck Game\DuckGame.xml
-
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.Linq;
 
 namespace DuckGame

--- a/DuckGame/src/DuckGame/SmartDuck/AIState.cs
+++ b/DuckGame/src/DuckGame/SmartDuck/AIState.cs
@@ -1,11 +1,4 @@
-﻿//// Decompiled with JetBrains decompiler
-//// Type: DuckGame.AIState
-////removed for regex reasons Culture=neutral, PublicKeyToken=null
-//// MVID: C907F20B-C12B-4773-9B1E-25290117C0E4
-//// Assembly location: D:\Program Files (x86)\Steam\steamapps\common\Duck Game\DuckGame.exe
-//// XML documentation location: D:\Program Files (x86)\Steam\steamapps\common\Duck Game\DuckGame.xml
-
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 
 namespace DuckGame
 {

--- a/DuckGame/src/DuckGame/SmartDuck/AIStateDeathmatchBot.cs
+++ b/DuckGame/src/DuckGame/SmartDuck/AIStateDeathmatchBot.cs
@@ -1,11 +1,4 @@
-﻿//// Decompiled with JetBrains decompiler
-//// Type: DuckGame.AIStateDeathmatchBot
-////removed for regex reasons Culture=neutral, PublicKeyToken=null
-//// MVID: C907F20B-C12B-4773-9B1E-25290117C0E4
-//// Assembly location: D:\Program Files (x86)\Steam\steamapps\common\Duck Game\DuckGame.exe
-//// XML documentation location: D:\Program Files (x86)\Steam\steamapps\common\Duck Game\DuckGame.xml
-
-namespace DuckGame
+﻿namespace DuckGame
 {
     public class AIStateDeathmatchBot : AIState
     {

--- a/DuckGame/src/DuckGame/SmartDuck/AIStateFindGun.cs
+++ b/DuckGame/src/DuckGame/SmartDuck/AIStateFindGun.cs
@@ -1,11 +1,4 @@
-﻿//// Decompiled with JetBrains decompiler
-//// Type: DuckGame.AIStateFindGun
-////removed for regex reasons Culture=neutral, PublicKeyToken=null
-//// MVID: C907F20B-C12B-4773-9B1E-25290117C0E4
-//// Assembly location: D:\Program Files (x86)\Steam\steamapps\common\Duck Game\DuckGame.exe
-//// XML documentation location: D:\Program Files (x86)\Steam\steamapps\common\Duck Game\DuckGame.xml
-
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Linq;
 

--- a/DuckGame/src/DuckGame/SmartDuck/AIStateFindTarget.cs
+++ b/DuckGame/src/DuckGame/SmartDuck/AIStateFindTarget.cs
@@ -1,11 +1,4 @@
-﻿//// Decompiled with JetBrains decompiler
-//// Type: DuckGame.AIStateFindTarget
-////removed for regex reasons Culture=neutral, PublicKeyToken=null
-//// MVID: C907F20B-C12B-4773-9B1E-25290117C0E4
-//// Assembly location: D:\Program Files (x86)\Steam\steamapps\common\Duck Game\DuckGame.exe
-//// XML documentation location: D:\Program Files (x86)\Steam\steamapps\common\Duck Game\DuckGame.xml
-
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Linq;
 

--- a/DuckGame/src/DuckGame/SmartDuck/AIStatePickHat.cs
+++ b/DuckGame/src/DuckGame/SmartDuck/AIStatePickHat.cs
@@ -1,11 +1,4 @@
-﻿//// Decompiled with JetBrains decompiler
-//// Type: DuckGame.AIStatePickHat
-////removed for regex reasons Culture=neutral, PublicKeyToken=null
-//// MVID: C907F20B-C12B-4773-9B1E-25290117C0E4
-//// Assembly location: D:\Program Files (x86)\Steam\steamapps\common\Duck Game\DuckGame.exe
-//// XML documentation location: D:\Program Files (x86)\Steam\steamapps\common\Duck Game\DuckGame.xml
-
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.Linq;
 
 namespace DuckGame

--- a/DuckGame/src/DuckGame/Spawners/SpawnerBall.cs
+++ b/DuckGame/src/DuckGame/Spawners/SpawnerBall.cs
@@ -1,11 +1,4 @@
-﻿// Decompiled with JetBrains decompiler
-// Type: DuckGame.SpawnerBall
-//removed for regex reasons Culture=neutral, PublicKeyToken=null
-// MVID: C907F20B-C12B-4773-9B1E-25290117C0E4
-// Assembly location: D:\Program Files (x86)\Steam\steamapps\common\Duck Game\DuckGame.exe
-// XML documentation location: D:\Program Files (x86)\Steam\steamapps\common\Duck Game\DuckGame.xml
-
-using System;
+﻿using System;
 
 namespace DuckGame
 {

--- a/DuckGame/src/DuckGame/Stuff/RagdollPart.cs
+++ b/DuckGame/src/DuckGame/Stuff/RagdollPart.cs
@@ -1,11 +1,4 @@
-﻿// Decompiled with JetBrains decompiler
-// Type: DuckGame.RagdollPart
-//removed for regex reasons Culture=neutral, PublicKeyToken=null
-// MVID: C907F20B-C12B-4773-9B1E-25290117C0E4
-// Assembly location: D:\Program Files (x86)\Steam\steamapps\common\Duck Game\DuckGame.exe
-// XML documentation location: D:\Program Files (x86)\Steam\steamapps\common\Duck Game\DuckGame.xml
-
-using System;
+﻿using System;
 using System.Collections.Generic;
 
 namespace DuckGame

--- a/DuckGame/src/DuckGame/Stuff/TargetDuck.cs
+++ b/DuckGame/src/DuckGame/Stuff/TargetDuck.cs
@@ -1,11 +1,4 @@
-﻿// Decompiled with JetBrains decompiler
-// Type: DuckGame.TargetDuck
-//removed for regex reasons Culture=neutral, PublicKeyToken=null
-// MVID: C907F20B-C12B-4773-9B1E-25290117C0E4
-// Assembly location: D:\Program Files (x86)\Steam\steamapps\common\Duck Game\DuckGame.exe
-// XML documentation location: D:\Program Files (x86)\Steam\steamapps\common\Duck Game\DuckGame.xml
-
-using Microsoft.Xna.Framework.Graphics;
+﻿using Microsoft.Xna.Framework.Graphics;
 using System;
 using System.Linq;
 

--- a/DuckGame/src/DuckGame/Stuff/Wires/WireActivator.cs
+++ b/DuckGame/src/DuckGame/Stuff/Wires/WireActivator.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 
 namespace DuckGame
 {
@@ -103,6 +104,15 @@ namespace DuckGame
                     action = true;
                     break;
             }
+        }
+
+        public override Type TabRotate(bool control)
+        {
+            if (control)
+                editorCycleType = typeof(WireButton);
+            else 
+                base.TabRotate();
+            return editorCycleType;
         }
     }
 }

--- a/DuckGame/src/DuckGame/Stuff/Wires/WireButton.cs
+++ b/DuckGame/src/DuckGame/Stuff/Wires/WireButton.cs
@@ -1,4 +1,5 @@
-﻿using System.Linq;
+﻿using System;
+using System.Linq;
 
 namespace DuckGame
 {
@@ -46,6 +47,15 @@ namespace DuckGame
             if ((int)orientation <= 3)
                 return;
             orientation = (EditorProperty<int>)0;
+        }
+
+        public override Type TabRotate(bool control)
+        {
+            if (control)
+                editorCycleType = typeof(WireFlipper);
+            else
+                TabRotate();
+            return editorCycleType;
         }
 
         public override void Initialize()

--- a/DuckGame/src/DuckGame/Stuff/Wires/WireFlipper.cs
+++ b/DuckGame/src/DuckGame/Stuff/Wires/WireFlipper.cs
@@ -1,4 +1,6 @@
-﻿namespace DuckGame
+﻿using System;
+
+namespace DuckGame
 {
     [EditorGroup("Stuff|Wires")]
     [BaggedProperty("isOnlineCapable", true)]
@@ -23,15 +25,21 @@
             _canFlip = true;
         }
 
+        public override Type TabRotate(bool control)
+        {
+            if (control)
+                editorCycleType = typeof(WireMount);
+            else
+                base.TabRotate();
+            return editorCycleType;
+        }
+
         public override void Initialize() => base.Initialize();
 
         public override void Draw()
         {
-            bool flipHorizontal = this.flipHorizontal;
-            _sprite.frame = offDir >= 0 ? 0 : 1;
-            this.flipHorizontal = false;
+           _sprite.frame = offDir >= 0 ? 0 : 1;
             base.Draw();
-            this.flipHorizontal = flipHorizontal;
         }
 
         public override void Update() => base.Update();

--- a/DuckGame/src/DuckGame/Stuff/Wires/WireMount.cs
+++ b/DuckGame/src/DuckGame/Stuff/Wires/WireMount.cs
@@ -1,4 +1,6 @@
-﻿namespace DuckGame
+﻿using System;
+
+namespace DuckGame
 {
     [EditorGroup("Stuff|Wires")]
     [BaggedProperty("isOnlineCapable", true)]
@@ -106,6 +108,15 @@
             if (contains != null)
                 text = contains.Name;
             Graphics.DrawString(text, position + new Vec2((float)(-Graphics.GetStringWidth(text) / 2), -16f), Color.White, (Depth)0.9f);
+        }
+
+        public override Type TabRotate(bool control)
+        {
+            if (control)
+                editorCycleType = typeof(WireTrapDoor);
+            else
+                base.TabRotate(control);
+            return editorCycleType;
         }
 
         public override void Initialize()

--- a/DuckGame/src/DuckGame/Stuff/Wires/WireTileset.cs
+++ b/DuckGame/src/DuckGame/Stuff/Wires/WireTileset.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 
 namespace DuckGame
 {
@@ -45,6 +46,15 @@ namespace DuckGame
             weight = 1f;
             _signalSprite = new Sprite("wireBulge");
             _signalSprite.CenterOrigin();
+        }
+
+        public override Type TabRotate(bool control)
+        {
+            if (control)
+                editorCycleType = typeof(WireActivator);
+            else
+                base.TabRotate(control);
+            return editorCycleType;
         }
 
         public void Emit(WireSignal signal = null, float overshoot = 0f, int type = 0)

--- a/DuckGame/src/DuckGame/Stuff/Wires/WireTrapDoor.cs
+++ b/DuckGame/src/DuckGame/Stuff/Wires/WireTrapDoor.cs
@@ -1,4 +1,6 @@
-﻿namespace DuckGame
+﻿using System;
+
+namespace DuckGame
 {
     [EditorGroup("Stuff|Wires")]
     [BaggedProperty("isOnlineCapable", true)]
@@ -15,6 +17,8 @@
         public EditorProperty<bool> fallthrough;
         private bool _lastFallthrough = true;
         public bool newTrapdoorVersion = true;
+        private float oldX;
+        private float oldY;
 
         public override bool flipHorizontal
         {
@@ -32,6 +36,16 @@
             }
         }
 
+        public override Type TabRotate(bool control)
+        {
+            if (control)
+                editorCycleType = typeof(WireTileset);
+            else
+                base.TabRotate();
+            return editorCycleType;
+        }
+
+
         public override void EditorPropertyChanged(object property)
         {
             if (!_initialized)
@@ -43,7 +57,8 @@
 
         private void UpdateShutter()
         {
-            if (_lastFallthrough != fallthrough.value)
+            bool inEditor = (Level.current is Editor);
+            if ( _lastFallthrough != fallthrough.value || (inEditor && (oldX != x || oldY != y)))
             {
                 Level.Remove(_shutter);
                 _shutter = null;
@@ -55,12 +70,14 @@
                 CreateShutter();
             }
             _lastFallthrough = fallthrough.value;
-            if (flag || Level.current is Editor)
+            if (flag || inEditor)
             {
                 if (_open)
                     _shutter.angleDegrees = 90f * offDir;
                 else
                     _shutter.angleDegrees = 0f;
+                oldX = x;
+                oldY = y;
             }
             else if (_open)
                 _shutter.angleDegrees = Lerp.Float(_shutter.angleDegrees, 90f * offDir, 10f);
@@ -132,6 +149,12 @@
         {
             UpdateShutter();
             base.Update();
+        }
+
+        public override void EditorUpdate()
+        {
+            UpdateShutter();
+            base.EditorUpdate();
         }
 
         public override void Terminate()

--- a/DuckGame/src/DuckGame/Weapons/Bullets/AmmoTypes/ATLaser.cs
+++ b/DuckGame/src/DuckGame/Weapons/Bullets/AmmoTypes/ATLaser.cs
@@ -1,11 +1,4 @@
-﻿// Decompiled with JetBrains decompiler
-// Type: DuckGame.ATLaser
-//removed for regex reasons Culture=neutral, PublicKeyToken=null
-// MVID: C907F20B-C12B-4773-9B1E-25290117C0E4
-// Assembly location: D:\Program Files (x86)\Steam\steamapps\common\Duck Game\DuckGame.exe
-// XML documentation location: D:\Program Files (x86)\Steam\steamapps\common\Duck Game\DuckGame.xml
-
-namespace DuckGame
+﻿namespace DuckGame
 {
     public class ATLaser : AmmoType
     {

--- a/DuckGame/src/DuckGame/Weapons/Bullets/AmmoTypes/PelletBullet.cs
+++ b/DuckGame/src/DuckGame/Weapons/Bullets/AmmoTypes/PelletBullet.cs
@@ -1,11 +1,4 @@
-﻿// Decompiled with JetBrains decompiler
-// Type: DuckGame.PelletBullet
-//removed for regex reasons Culture=neutral, PublicKeyToken=null
-// MVID: C907F20B-C12B-4773-9B1E-25290117C0E4
-// Assembly location: D:\Program Files (x86)\Steam\steamapps\common\Duck Game\DuckGame.exe
-// XML documentation location: D:\Program Files (x86)\Steam\steamapps\common\Duck Game\DuckGame.xml
-
-namespace DuckGame
+﻿namespace DuckGame
 {
     public class PelletBullet : Bullet
     {

--- a/DuckGame/src/DuckGame/Weapons/Bullets/LaserBullet.cs
+++ b/DuckGame/src/DuckGame/Weapons/Bullets/LaserBullet.cs
@@ -1,11 +1,4 @@
-﻿// Decompiled with JetBrains decompiler
-// Type: DuckGame.LaserBullet
-//removed for regex reasons Culture=neutral, PublicKeyToken=null
-// MVID: C907F20B-C12B-4773-9B1E-25290117C0E4
-// Assembly location: D:\Program Files (x86)\Steam\steamapps\common\Duck Game\DuckGame.exe
-// XML documentation location: D:\Program Files (x86)\Steam\steamapps\common\Duck Game\DuckGame.xml
-
-using Microsoft.Xna.Framework.Graphics;
+﻿using Microsoft.Xna.Framework.Graphics;
 using System;
 using System.Linq;
 

--- a/DuckGame/src/DuckGame/Weapons/Bullets/LaserBulletOrange.cs
+++ b/DuckGame/src/DuckGame/Weapons/Bullets/LaserBulletOrange.cs
@@ -1,11 +1,4 @@
-﻿// Decompiled with JetBrains decompiler
-// Type: DuckGame.LaserBulletOrange
-//removed for regex reasons Culture=neutral, PublicKeyToken=null
-// MVID: C907F20B-C12B-4773-9B1E-25290117C0E4
-// Assembly location: D:\Program Files (x86)\Steam\steamapps\common\Duck Game\DuckGame.exe
-// XML documentation location: D:\Program Files (x86)\Steam\steamapps\common\Duck Game\DuckGame.xml
-
-using Microsoft.Xna.Framework.Graphics;
+﻿using Microsoft.Xna.Framework.Graphics;
 
 namespace DuckGame
 {

--- a/DuckGame/src/DuckGame/Weapons/Bullets/LaserBulletPurple.cs
+++ b/DuckGame/src/DuckGame/Weapons/Bullets/LaserBulletPurple.cs
@@ -1,11 +1,4 @@
-﻿// Decompiled with JetBrains decompiler
-// Type: DuckGame.LaserBulletPurple
-//removed for regex reasons Culture=neutral, PublicKeyToken=null
-// MVID: C907F20B-C12B-4773-9B1E-25290117C0E4
-// Assembly location: D:\Program Files (x86)\Steam\steamapps\common\Duck Game\DuckGame.exe
-// XML documentation location: D:\Program Files (x86)\Steam\steamapps\common\Duck Game\DuckGame.xml
-
-using Microsoft.Xna.Framework.Graphics;
+﻿using Microsoft.Xna.Framework.Graphics;
 
 namespace DuckGame
 {

--- a/DuckGame/src/DuckGame/Weapons/Bullets/MagBullet.cs
+++ b/DuckGame/src/DuckGame/Weapons/Bullets/MagBullet.cs
@@ -1,11 +1,4 @@
-﻿// Decompiled with JetBrains decompiler
-// Type: DuckGame.MagBullet
-//removed for regex reasons Culture=neutral, PublicKeyToken=null
-// MVID: C907F20B-C12B-4773-9B1E-25290117C0E4
-// Assembly location: D:\Program Files (x86)\Steam\steamapps\common\Duck Game\DuckGame.exe
-// XML documentation location: D:\Program Files (x86)\Steam\steamapps\common\Duck Game\DuckGame.xml
-
-using Microsoft.Xna.Framework.Graphics;
+﻿using Microsoft.Xna.Framework.Graphics;
 
 namespace DuckGame
 {

--- a/DuckGame/src/DuckGame/Weapons/Bullets/PhysicalBullet.cs
+++ b/DuckGame/src/DuckGame/Weapons/Bullets/PhysicalBullet.cs
@@ -1,11 +1,4 @@
-﻿// Decompiled with JetBrains decompiler
-// Type: DuckGame.PhysicalBullet
-//removed for regex reasons Culture=neutral, PublicKeyToken=null
-// MVID: C907F20B-C12B-4773-9B1E-25290117C0E4
-// Assembly location: D:\Program Files (x86)\Steam\steamapps\common\Duck Game\DuckGame.exe
-// XML documentation location: D:\Program Files (x86)\Steam\steamapps\common\Duck Game\DuckGame.xml
-
-namespace DuckGame
+﻿namespace DuckGame
 {
     public class PhysicalBullet : MaterialThing
     {

--- a/DuckGame/src/DuckGame/Weapons/Bullets/PortalBullet.cs
+++ b/DuckGame/src/DuckGame/Weapons/Bullets/PortalBullet.cs
@@ -1,11 +1,4 @@
-﻿// Decompiled with JetBrains decompiler
-// Type: DuckGame.PortalBullet
-//removed for regex reasons Culture=neutral, PublicKeyToken=null
-// MVID: C907F20B-C12B-4773-9B1E-25290117C0E4
-// Assembly location: D:\Program Files (x86)\Steam\steamapps\common\Duck Game\DuckGame.exe
-// XML documentation location: D:\Program Files (x86)\Steam\steamapps\common\Duck Game\DuckGame.xml
-
-using Microsoft.Xna.Framework.Graphics;
+﻿using Microsoft.Xna.Framework.Graphics;
 using System;
 using System.Linq;
 

--- a/DuckGame/src/DuckGame/Weapons/ChaingunBullet.cs
+++ b/DuckGame/src/DuckGame/Weapons/ChaingunBullet.cs
@@ -1,11 +1,4 @@
-﻿// Decompiled with JetBrains decompiler
-// Type: DuckGame.ChaingunBullet
-//removed for regex reasons Culture=neutral, PublicKeyToken=null
-// MVID: C907F20B-C12B-4773-9B1E-25290117C0E4
-// Assembly location: D:\Program Files (x86)\Steam\steamapps\common\Duck Game\DuckGame.exe
-// XML documentation location: D:\Program Files (x86)\Steam\steamapps\common\Duck Game\DuckGame.xml
-
-using System;
+﻿using System;
 
 namespace DuckGame
 {

--- a/DuckGame/src/DuckGame/Weapons/MagBlaster.cs
+++ b/DuckGame/src/DuckGame/Weapons/MagBlaster.cs
@@ -1,11 +1,4 @@
-﻿// Decompiled with JetBrains decompiler
-// Type: DuckGame.MagBlaster
-//removed for regex reasons Culture=neutral, PublicKeyToken=null
-// MVID: C907F20B-C12B-4773-9B1E-25290117C0E4
-// Assembly location: D:\Program Files (x86)\Steam\steamapps\common\Duck Game\DuckGame.exe
-// XML documentation location: D:\Program Files (x86)\Steam\steamapps\common\Duck Game\DuckGame.xml
-
-namespace DuckGame
+﻿namespace DuckGame
 {
     [EditorGroup("Guns|Pistols")]
     [BaggedProperty("isInDemo", true)]

--- a/DuckGame/src/DuckGame/Weapons/MagnetGun.cs
+++ b/DuckGame/src/DuckGame/Weapons/MagnetGun.cs
@@ -1,11 +1,4 @@
-﻿// Decompiled with JetBrains decompiler
-// Type: DuckGame.MagnetGun
-//removed for regex reasons Culture=neutral, PublicKeyToken=null
-// MVID: C907F20B-C12B-4773-9B1E-25290117C0E4
-// Assembly location: D:\Program Files (x86)\Steam\steamapps\common\Duck Game\DuckGame.exe
-// XML documentation location: D:\Program Files (x86)\Steam\steamapps\common\Duck Game\DuckGame.xml
-
-using Microsoft.Xna.Framework.Audio;
+﻿using Microsoft.Xna.Framework.Audio;
 using System;
 using System.Collections.Generic;
 

--- a/DuckGame/src/DuckGame/Weapons/Sniper.cs
+++ b/DuckGame/src/DuckGame/Weapons/Sniper.cs
@@ -1,11 +1,4 @@
-﻿// Decompiled with JetBrains decompiler
-// Type: DuckGame.Sniper
-//removed for regex reasons Culture=neutral, PublicKeyToken=null
-// MVID: C907F20B-C12B-4773-9B1E-25290117C0E4
-// Assembly location: D:\Program Files (x86)\Steam\steamapps\common\Duck Game\DuckGame.exe
-// XML documentation location: D:\Program Files (x86)\Steam\steamapps\common\Duck Game\DuckGame.xml
-
-namespace DuckGame
+﻿namespace DuckGame
 {
     [EditorGroup("Guns|Rifles")]
     public class Sniper : Gun

--- a/DuckGame/src/MonoTime/Content/Content.cs
+++ b/DuckGame/src/MonoTime/Content/Content.cs
@@ -1,11 +1,4 @@
-﻿// Decompiled with JetBrains decompiler
-// Type: DuckGame.Content
-//removed for regex reasons Culture=neutral, PublicKeyToken=null
-// MVID: C907F20B-C12B-4773-9B1E-25290117C0E4
-// Assembly location: D:\Program Files (x86)\Steam\steamapps\common\Duck Game\DuckGame.exe
-// XML documentation location: D:\Program Files (x86)\Steam\steamapps\common\Duck Game\DuckGame.xml
-
-using Microsoft.Xna.Framework.Content;
+﻿using Microsoft.Xna.Framework.Content;
 using Microsoft.Xna.Framework.Graphics;
 using NAudio.Wave;
 using System;

--- a/DuckGame/src/MonoTime/Debug.cs
+++ b/DuckGame/src/MonoTime/Debug.cs
@@ -1,11 +1,4 @@
-﻿// Decompiled with JetBrains decompiler
-// Type: DuckGame.Debug
-//removed for regex reasons Culture=neutral, PublicKeyToken=null
-// MVID: C907F20B-C12B-4773-9B1E-25290117C0E4
-// Assembly location: D:\Program Files (x86)\Steam\steamapps\common\Duck Game\DuckGame.exe
-// XML documentation location: D:\Program Files (x86)\Steam\steamapps\common\Duck Game\DuckGame.xml
-
-using Microsoft.Xna.Framework.Graphics;
+﻿using Microsoft.Xna.Framework.Graphics;
 using System;
 using System.Diagnostics;
 

--- a/DuckGame/src/MonoTime/DrawList.cs
+++ b/DuckGame/src/MonoTime/DrawList.cs
@@ -1,11 +1,4 @@
-﻿// Decompiled with JetBrains decompiler
-// Type: DuckGame.DrawList
-//removed for regex reasons Culture=neutral, PublicKeyToken=null
-// MVID: C907F20B-C12B-4773-9B1E-25290117C0E4
-// Assembly location: D:\Program Files (x86)\Steam\steamapps\common\Duck Game\DuckGame.exe
-// XML documentation location: D:\Program Files (x86)\Steam\steamapps\common\Duck Game\DuckGame.xml
-
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 
 namespace DuckGame
 {

--- a/DuckGame/src/MonoTime/Input/BullshitInput.cs
+++ b/DuckGame/src/MonoTime/Input/BullshitInput.cs
@@ -1,11 +1,4 @@
-﻿//// Decompiled with JetBrains decompiler
-//// Type: DuckGame.BullshitInput
-////removed for regex reasons Culture=neutral, PublicKeyToken=null
-//// MVID: C907F20B-C12B-4773-9B1E-25290117C0E4
-//// Assembly location: D:\Program Files (x86)\Steam\steamapps\common\Duck Game\DuckGame.exe
-//// XML documentation location: D:\Program Files (x86)\Steam\steamapps\common\Duck Game\DuckGame.xml
-
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 
 namespace DuckGame
 {

--- a/DuckGame/src/MonoTime/Layer.cs
+++ b/DuckGame/src/MonoTime/Layer.cs
@@ -1,11 +1,4 @@
-﻿// Decompiled with JetBrains decompiler
-// Type: DuckGame.Layer
-//removed for regex reasons Culture=neutral, PublicKeyToken=null
-// MVID: C907F20B-C12B-4773-9B1E-25290117C0E4
-// Assembly location: D:\Program Files (x86)\Steam\steamapps\common\Duck Game\DuckGame.exe
-// XML documentation location: D:\Program Files (x86)\Steam\steamapps\common\Duck Game\DuckGame.xml
-
-using Microsoft.Xna.Framework;
+﻿using Microsoft.Xna.Framework;
 using Microsoft.Xna.Framework.Graphics;
 using System;
 using System.Collections.Generic;

--- a/DuckGame/src/MonoTime/LayerCore.cs
+++ b/DuckGame/src/MonoTime/LayerCore.cs
@@ -1,11 +1,4 @@
-﻿// Decompiled with JetBrains decompiler
-// Type: DuckGame.LayerCore
-//removed for regex reasons Culture=neutral, PublicKeyToken=null
-// MVID: C907F20B-C12B-4773-9B1E-25290117C0E4
-// Assembly location: D:\Program Files (x86)\Steam\steamapps\common\Duck Game\DuckGame.exe
-// XML documentation location: D:\Program Files (x86)\Steam\steamapps\common\Duck Game\DuckGame.xml
-
-using Microsoft.Xna.Framework.Graphics;
+﻿using Microsoft.Xna.Framework.Graphics;
 using System;
 using System.Collections.Generic;
 using System.Linq;

--- a/DuckGame/src/MonoTime/LevelEditor/Editor.cs
+++ b/DuckGame/src/MonoTime/LevelEditor/Editor.cs
@@ -3866,12 +3866,12 @@ namespace DuckGame
                         if (vec2.y < 32)
                             vec2.y = 32f;
                         Vec2 p1 = new Vec2(19f, (float)(layer.height - 19 - vec2.y - (num24 + 10)) + num22);
-                        string str10 = thing.GetDetailsString();
-                        while (str10.Count(x => x == '\n') > 5)
-                            str10 = str10.Substring(0, str10.LastIndexOf('\n'));
-                        float x2 = _font.GetWidth(str10) + 8f;
-                        if (str10 != "")
-                            _font.Draw(str10, (float)(p1.x + vec2.x + 4), p1.y + 4f, Color.White, 0.7f);
+                        string detailsString = thing.GetDetailsString();
+                        while (detailsString.Count(x => x == '\n') > 5)
+                            detailsString = detailsString.Substring(0, detailsString.LastIndexOf('\n'));
+                        float x2 = _font.GetWidth(detailsString) + 8f;
+                        if (detailsString != "")
+                            _font.Draw(detailsString, (float)(p1.x + vec2.x + 4), p1.y + 4f, Color.White, 0.7f);
                         else
                             x2 = 0f;
                         Graphics.DrawRect(p1, p1 + vec2 + new Vec2(x2, 0f), Color.Black * 0.5f, 0.6f);
@@ -4699,16 +4699,16 @@ namespace DuckGame
             _currentLevelData.proceduralData.sideMask = 0;
             if (_miniMode)
             {
-                int num7 = 0;
+                int pathSidesMask = 0;
                 if (_pathNorth)
-                    num7 |= 1;
+                    pathSidesMask |= 1;
                 if (_pathEast)
-                    num7 |= 2;
+                    pathSidesMask |= 2;
                 if (_pathSouth)
-                    num7 |= 4;
+                    pathSidesMask |= 4;
                 if (_pathWest)
-                    num7 |= 8;
-                _currentLevelData.proceduralData.sideMask = num7;
+                    pathSidesMask |= 8;
+                _currentLevelData.proceduralData.sideMask = pathSidesMask;
                 _currentLevelData.proceduralData.weaponConfig = weaponConfig;
                 _currentLevelData.proceduralData.spawnerConfig = spawnerConfig;
                 _currentLevelData.proceduralData.numArmor = numArmor;

--- a/DuckGame/src/MonoTime/LevelEditor/Editor.cs
+++ b/DuckGame/src/MonoTime/LevelEditor/Editor.cs
@@ -2277,22 +2277,22 @@ namespace DuckGame
                                             break;
                                     }
 
-                                    bool flag3 = Keyboard.Down(Keys.LeftAlt) || Keyboard.Down(Keys.RightAlt);
-                                    bool flag4 = Keyboard.Down(Keys.LeftControl) || Keyboard.Down(Keys.RightControl);
-                                    bool flag5 = false;
-                                    if (flag3 & flag4)
+                                    bool altDown = Keyboard.Down(Keys.LeftAlt) || Keyboard.Down(Keys.RightAlt);
+                                    bool controlDown = Keyboard.Down(Keys.LeftControl) || Keyboard.Down(Keys.RightControl);
+                                    bool altAndControlDown = false;
+                                    if (altDown & controlDown)
                                     {
                                         _hover = null;
                                         _secondaryHover = null;
-                                        flag5 = true;
+                                        altAndControlDown = true;
                                     }
 
                                     if ((inputMode == EditorInput.Gamepad ||
                                          inputMode == EditorInput.Touch) && _placementMenu == null)
                                     {
-                                        int num13 = 1;
+                                        int stickSpeedModifier = 1;
                                         if (_input.Down(Triggers.LeftStick))
-                                            num13 = 4;
+                                            stickSpeedModifier = 4;
                                         _tilePosition = _tilePositionPrev;
                                         if (_tilePosition.x < camera.left)
                                             _tilePosition.x = camera.left + 32f;
@@ -2316,8 +2316,8 @@ namespace DuckGame
                                                 num14 = 1;
                                         }
 
-                                        float num16 = _cellSize * num13 * num15;
-                                        float num17 = _cellSize * num13 * num14;
+                                        float num16 = _cellSize * stickSpeedModifier * num15;
+                                        float num17 = _cellSize * stickSpeedModifier * num14;
                                         _tilePosition.x += num16;
                                         _tilePosition.y += num17;
                                         if (_tilePosition.x < camera.left || _tilePosition.x > camera.right)
@@ -2345,7 +2345,7 @@ namespace DuckGame
                                     }
                                     else if (inputMode == EditorInput.Mouse)
                                     {
-                                        if (flag3)
+                                        if (altDown)
                                         {
                                             _tilePosition.x = (float)Math.Round(Mouse.positionScreen.x / 1f) * 1f;
                                             _tilePosition.y = (float)Math.Round(Mouse.positionScreen.y / 1f) * 1f;
@@ -2362,7 +2362,7 @@ namespace DuckGame
                                     if (_placementType != null && _placementMenu == null)
                                     {
                                         _tilePosition += _placementType.editorOffset;
-                                        if (!flag3)
+                                        if (!altDown)
                                             HugObjectPlacement();
                                     }
 
@@ -2456,7 +2456,7 @@ namespace DuckGame
                                                             thing = null;
                                                         else if (thing != null && !_levelThings.Contains(thing))
                                                             thing = null;
-                                                        else if (flag4 & flag3)
+                                                        else if (altAndControlDown)
                                                             thing = null;
                                                         else if (_placementType is BackgroundTile &&
                                                                  !(thing is BackgroundTile))
@@ -2505,7 +2505,7 @@ namespace DuckGame
                                                                 () => RemoveObject(newThing));
                                                             if (newThing is PathNode)
                                                                 _editorLoadFinished = true;
-                                                            if (flag5)
+                                                            if (altAndControlDown)
                                                                 disableDragMode();
                                                         }
                                                     }
@@ -4593,14 +4593,14 @@ namespace DuckGame
                 }
             }
 
-            string str1 = "";
-            string str2 = "";
-            int num1 = 0;
-            int num2 = 0;
-            int num3 = 0;
-            int num4 = 0;
-            int num5 = 0;
-            int num6 = 0;
+            string weaponConfig = "";
+            string spawnerConfig = "";
+            int numArmor = 0;
+            int numEquipment = 0;
+            int numSpawns = 0;
+            int numTeamSpawns = 0;
+            int numLockedDoors = 0;
+            int numKeys = 0;
             _currentLevelData.metaData.eightPlayer = false;
             _currentLevelData.metaData.eightPlayerRestricted = false;
             _currentLevelData.objects.objects.Clear();
@@ -4623,24 +4623,24 @@ namespace DuckGame
                             switch (levelThing)
                             {
                                 case Key _:
-                                    ++num6;
+                                    ++numKeys;
                                     break;
                                 case Door _ when (levelThing as Door).locked:
-                                    ++num5;
+                                    ++numLockedDoors;
                                     break;
                                 case Equipment _:
                                     if (levelThing is ChestPlate || levelThing is Helmet || levelThing is KnightHelmet)
                                     {
-                                        ++num1;
+                                        ++numArmor;
                                         break;
                                     }
 
-                                    ++num2;
+                                    ++numEquipment;
                                     break;
                                 case Gun _:
-                                    if (str1 != "")
-                                        str1 += "|";
-                                    str1 += ModLoader.SmallTypeName(levelThing.GetType());
+                                    if (weaponConfig != "")
+                                        weaponConfig += "|";
+                                    weaponConfig += ModLoader.SmallTypeName(levelThing.GetType());
                                     break;
                                 case ItemSpawner _:
                                     ItemSpawner itemSpawner = levelThing as ItemSpawner;
@@ -4650,14 +4650,14 @@ namespace DuckGame
                                         if (itemSpawner.spawnNum < 1 && itemSpawner.spawnTime < 8f &&
                                             itemSpawner.isAccessible)
                                         {
-                                            if (str2 != "")
-                                                str2 += "|";
-                                            str2 += ModLoader.SmallTypeName(itemSpawner.contains);
+                                            if (spawnerConfig != "")
+                                                spawnerConfig += "|";
+                                            spawnerConfig += ModLoader.SmallTypeName(itemSpawner.contains);
                                         }
 
-                                        if (str1 != "")
-                                            str1 += "|";
-                                        str1 += ModLoader.SmallTypeName(itemSpawner.contains);
+                                        if (weaponConfig != "")
+                                            weaponConfig += "|";
+                                        weaponConfig += ModLoader.SmallTypeName(itemSpawner.contains);
                                     }
 
                                     break;
@@ -4668,21 +4668,21 @@ namespace DuckGame
                                         if (typeof(Gun).IsAssignableFrom(itemBox.contains) &&
                                             itemBox.likelyhoodToExist == 1f && itemBox.isAccessible)
                                         {
-                                            if (str2 != "")
-                                                str2 += "|";
-                                            str2 += ModLoader.SmallTypeName(itemBox.contains);
-                                            if (str1 != "")
-                                                str1 += "|";
-                                            str1 += ModLoader.SmallTypeName(itemBox.contains);
+                                            if (spawnerConfig != "")
+                                                spawnerConfig += "|";
+                                            spawnerConfig += ModLoader.SmallTypeName(itemBox.contains);
+                                            if (weaponConfig != "")
+                                                weaponConfig += "|";
+                                            weaponConfig += ModLoader.SmallTypeName(itemBox.contains);
                                         }
                                     }
                                     else if (levelThing is SpawnPoint)
                                     {
-                                        ++num3;
+                                        ++numSpawns;
                                     }
                                     else if (levelThing is TeamSpawn)
                                     {
-                                        ++num4;
+                                        ++numTeamSpawns;
                                     }
 
                                     break;
@@ -4709,14 +4709,14 @@ namespace DuckGame
                 if (_pathWest)
                     num7 |= 8;
                 _currentLevelData.proceduralData.sideMask = num7;
-                _currentLevelData.proceduralData.weaponConfig = str1;
-                _currentLevelData.proceduralData.spawnerConfig = str2;
-                _currentLevelData.proceduralData.numArmor = num1;
-                _currentLevelData.proceduralData.numEquipment = num2;
-                _currentLevelData.proceduralData.numSpawns = num3;
-                _currentLevelData.proceduralData.numTeamSpawns = num4;
-                _currentLevelData.proceduralData.numLockedDoors = num5;
-                _currentLevelData.proceduralData.numKeys = num6;
+                _currentLevelData.proceduralData.weaponConfig = weaponConfig;
+                _currentLevelData.proceduralData.spawnerConfig = spawnerConfig;
+                _currentLevelData.proceduralData.numArmor = numArmor;
+                _currentLevelData.proceduralData.numEquipment = numEquipment;
+                _currentLevelData.proceduralData.numSpawns = numSpawns;
+                _currentLevelData.proceduralData.numTeamSpawns = numTeamSpawns;
+                _currentLevelData.proceduralData.numLockedDoors = numLockedDoors;
+                _currentLevelData.proceduralData.numKeys = numKeys;
             }
 
             if (previewCapture != null)

--- a/DuckGame/src/MonoTime/LevelEditor/FieldBinding.cs
+++ b/DuckGame/src/MonoTime/LevelEditor/FieldBinding.cs
@@ -1,11 +1,4 @@
-﻿// Decompiled with JetBrains decompiler
-// Type: DuckGame.FieldBinding
-//removed for regex reasons Culture=neutral, PublicKeyToken=null
-// MVID: C907F20B-C12B-4773-9B1E-25290117C0E4
-// Assembly location: D:\Program Files (x86)\Steam\steamapps\common\Duck Game\DuckGame.exe
-// XML documentation location: D:\Program Files (x86)\Steam\steamapps\common\Duck Game\DuckGame.xml
-
-using System;
+﻿using System;
 using System.Reflection;
 
 namespace DuckGame

--- a/DuckGame/src/MonoTime/Materials/MaterialEnergyBlade.cs
+++ b/DuckGame/src/MonoTime/Materials/MaterialEnergyBlade.cs
@@ -1,11 +1,4 @@
-﻿// Decompiled with JetBrains decompiler
-// Type: DuckGame.MaterialEnergyBlade
-//removed for regex reasons Culture=neutral, PublicKeyToken=null
-// MVID: C907F20B-C12B-4773-9B1E-25290117C0E4
-// Assembly location: D:\Program Files (x86)\Steam\steamapps\common\Duck Game\DuckGame.exe
-// XML documentation location: D:\Program Files (x86)\Steam\steamapps\common\Duck Game\DuckGame.xml
-
-using Microsoft.Xna.Framework.Graphics;
+﻿using Microsoft.Xna.Framework.Graphics;
 
 namespace DuckGame
 {

--- a/DuckGame/src/MonoTime/Materials/MaterialPause.cs
+++ b/DuckGame/src/MonoTime/Materials/MaterialPause.cs
@@ -1,11 +1,4 @@
-﻿// Decompiled with JetBrains decompiler
-// Type: DuckGame.MaterialPause
-//removed for regex reasons Culture=neutral, PublicKeyToken=null
-// MVID: C907F20B-C12B-4773-9B1E-25290117C0E4
-// Assembly location: D:\Program Files (x86)\Steam\steamapps\common\Duck Game\DuckGame.exe
-// XML documentation location: D:\Program Files (x86)\Steam\steamapps\common\Duck Game\DuckGame.xml
-
-using Microsoft.Xna.Framework.Graphics;
+﻿using Microsoft.Xna.Framework.Graphics;
 
 namespace DuckGame
 {

--- a/DuckGame/src/MonoTime/Modding/DisabledMod.cs
+++ b/DuckGame/src/MonoTime/Modding/DisabledMod.cs
@@ -1,11 +1,4 @@
-﻿// Decompiled with JetBrains decompiler
-// Type: DuckGame.DisabledMod
-//removed for regex reasons Culture=neutral, PublicKeyToken=null
-// MVID: C907F20B-C12B-4773-9B1E-25290117C0E4
-// Assembly location: D:\Program Files (x86)\Steam\steamapps\common\Duck Game\DuckGame.exe
-// XML documentation location: D:\Program Files (x86)\Steam\steamapps\common\Duck Game\DuckGame.xml
-
-namespace DuckGame
+﻿namespace DuckGame
 {
     /// <summary>Dummy Mod class used to store disabled mods.</summary>
     public class DisabledMod : Mod

--- a/DuckGame/src/MonoTime/Modding/ModLoader/BaggedPropertyAttribute.cs
+++ b/DuckGame/src/MonoTime/Modding/ModLoader/BaggedPropertyAttribute.cs
@@ -1,11 +1,4 @@
-﻿// Decompiled with JetBrains decompiler
-// Type: DuckGame.BaggedPropertyAttribute
-//removed for regex reasons Culture=neutral, PublicKeyToken=null
-// MVID: C907F20B-C12B-4773-9B1E-25290117C0E4
-// Assembly location: D:\Program Files (x86)\Steam\steamapps\common\Duck Game\DuckGame.exe
-// XML documentation location: D:\Program Files (x86)\Steam\steamapps\common\Duck Game\DuckGame.xml
-
-using System;
+﻿using System;
 
 namespace DuckGame
 {

--- a/DuckGame/src/MonoTime/Modding/ModLoader/ContentManagers.cs
+++ b/DuckGame/src/MonoTime/Modding/ModLoader/ContentManagers.cs
@@ -1,11 +1,4 @@
-﻿// Decompiled with JetBrains decompiler
-// Type: DuckGame.ContentManagers
-//removed for regex reasons Culture=neutral, PublicKeyToken=null
-// MVID: C907F20B-C12B-4773-9B1E-25290117C0E4
-// Assembly location: D:\Program Files (x86)\Steam\steamapps\common\Duck Game\DuckGame.exe
-// XML documentation location: D:\Program Files (x86)\Steam\steamapps\common\Duck Game\DuckGame.xml
-
-using System;
+﻿using System;
 using System.Collections.Generic;
 
 namespace DuckGame

--- a/DuckGame/src/MonoTime/Modding/WorkshopContent.cs
+++ b/DuckGame/src/MonoTime/Modding/WorkshopContent.cs
@@ -1,11 +1,4 @@
-﻿// Decompiled with JetBrains decompiler
-// Type: DuckGame.WorkshopContent
-//removed for regex reasons Culture=neutral, PublicKeyToken=null
-// MVID: C907F20B-C12B-4773-9B1E-25290117C0E4
-// Assembly location: D:\Program Files (x86)\Steam\steamapps\common\Duck Game\DuckGame.exe
-// XML documentation location: D:\Program Files (x86)\Steam\steamapps\common\Duck Game\DuckGame.xml
-
-namespace DuckGame
+﻿namespace DuckGame
 {
     public class WorkshopContent
     {

--- a/DuckGame/src/MonoTime/Modding/WorkshopMap.cs
+++ b/DuckGame/src/MonoTime/Modding/WorkshopMap.cs
@@ -1,11 +1,4 @@
-﻿// Decompiled with JetBrains decompiler
-// Type: DuckGame.WorkshopMap
-//removed for regex reasons Culture=neutral, PublicKeyToken=null
-// MVID: C907F20B-C12B-4773-9B1E-25290117C0E4
-// Assembly location: D:\Program Files (x86)\Steam\steamapps\common\Duck Game\DuckGame.exe
-// XML documentation location: D:\Program Files (x86)\Steam\steamapps\common\Duck Game\DuckGame.xml
-
-namespace DuckGame
+﻿namespace DuckGame
 {
     public class WorkshopMap : WorkshopContent
     {

--- a/DuckGame/src/MonoTime/MonoMain.cs
+++ b/DuckGame/src/MonoTime/MonoMain.cs
@@ -1,11 +1,4 @@
-﻿// Decompiled with JetBrains decompiler
-// Type: DuckGame.MonoMain
-//removed for regex reasons Culture=neutral, PublicKeyToken=null
-// MVID: C907F20B-C12B-4773-9B1E-25290117C0E4
-// Assembly location: D:\Program Files (x86)\Steam\steamapps\common\Duck Game\DuckGame.exe
-// XML documentation location: D:\Program Files (x86)\Steam\steamapps\common\Duck Game\DuckGame.xml
-
-using AddedContent.Firebreak;
+﻿using AddedContent.Firebreak;
 using Microsoft.Xna.Framework;
 using Microsoft.Xna.Framework.Graphics;
 using SDL2;

--- a/DuckGame/src/MonoTime/MonoMainCore.cs
+++ b/DuckGame/src/MonoTime/MonoMainCore.cs
@@ -1,11 +1,4 @@
-﻿// Decompiled with JetBrains decompiler
-// Type: DuckGame.MonoMainCore
-//removed for regex reasons Culture=neutral, PublicKeyToken=null
-// MVID: C907F20B-C12B-4773-9B1E-25290117C0E4
-// Assembly location: D:\Program Files (x86)\Steam\steamapps\common\Duck Game\DuckGame.exe
-// XML documentation location: D:\Program Files (x86)\Steam\steamapps\common\Duck Game\DuckGame.xml
-
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 
 namespace DuckGame
 {

--- a/DuckGame/src/MonoTime/Render/Camera.cs
+++ b/DuckGame/src/MonoTime/Render/Camera.cs
@@ -1,11 +1,4 @@
-﻿// Decompiled with JetBrains decompiler
-// Type: DuckGame.Camera
-//removed for regex reasons Culture=neutral, PublicKeyToken=null
-// MVID: C907F20B-C12B-4773-9B1E-25290117C0E4
-// Assembly location: D:\Program Files (x86)\Steam\steamapps\common\Duck Game\DuckGame.exe
-// XML documentation location: D:\Program Files (x86)\Steam\steamapps\common\Duck Game\DuckGame.xml
-
-using Microsoft.Xna.Framework.Graphics;
+﻿using Microsoft.Xna.Framework.Graphics;
 using System;
 
 namespace DuckGame

--- a/DuckGame/src/MonoTime/Render/RasterFont.cs
+++ b/DuckGame/src/MonoTime/Render/RasterFont.cs
@@ -1,11 +1,4 @@
-﻿// Decompiled with JetBrains decompiler
-// Type: DuckGame.RasterFont
-//removed for regex reasons Culture=neutral, PublicKeyToken=null
-// MVID: C907F20B-C12B-4773-9B1E-25290117C0E4
-// Assembly location: D:\Program Files (x86)\Steam\steamapps\common\Duck Game\DuckGame.exe
-// XML documentation location: D:\Program Files (x86)\Steam\steamapps\common\Duck Game\DuckGame.xml
-
-using System;
+﻿using System;
 using System.Collections.Generic;
 
 namespace DuckGame

--- a/DuckGame/src/MonoTime/Render/Sprite.cs
+++ b/DuckGame/src/MonoTime/Render/Sprite.cs
@@ -1,11 +1,4 @@
-﻿// Decompiled with JetBrains decompiler
-// Type: DuckGame.Sprite
-//removed for regex reasons Culture=neutral, PublicKeyToken=null
-// MVID: C907F20B-C12B-4773-9B1E-25290117C0E4
-// Assembly location: D:\Program Files (x86)\Steam\steamapps\common\Duck Game\DuckGame.exe
-// XML documentation location: D:\Program Files (x86)\Steam\steamapps\common\Duck Game\DuckGame.xml
-
-using Microsoft.Xna.Framework.Graphics;
+﻿using Microsoft.Xna.Framework.Graphics;
 using System;
 
 namespace DuckGame

--- a/DuckGame/src/MonoTime/Render/SpriteMap.cs
+++ b/DuckGame/src/MonoTime/Render/SpriteMap.cs
@@ -1,11 +1,4 @@
-﻿// Decompiled with JetBrains decompiler
-// Type: DuckGame.SpriteMap
-//removed for regex reasons Culture=neutral, PublicKeyToken=null
-// MVID: C907F20B-C12B-4773-9B1E-25290117C0E4
-// Assembly location: D:\Program Files (x86)\Steam\steamapps\common\Duck Game\DuckGame.exe
-// XML documentation location: D:\Program Files (x86)\Steam\steamapps\common\Duck Game\DuckGame.xml
-
-using Microsoft.Xna.Framework.Graphics;
+﻿using Microsoft.Xna.Framework.Graphics;
 using System;
 using System.Collections.Generic;
 using System.Security.Policy;

--- a/DuckGame/src/MonoTime/Resources/MTEffect.cs
+++ b/DuckGame/src/MonoTime/Resources/MTEffect.cs
@@ -1,11 +1,4 @@
-﻿// Decompiled with JetBrains decompiler
-// Type: DuckGame.MTEffect
-//removed for regex reasons Culture=neutral, PublicKeyToken=null
-// MVID: C907F20B-C12B-4773-9B1E-25290117C0E4
-// Assembly location: D:\Program Files (x86)\Steam\steamapps\common\Duck Game\DuckGame.exe
-// XML documentation location: D:\Program Files (x86)\Steam\steamapps\common\Duck Game\DuckGame.xml
-
-using Microsoft.Xna.Framework.Graphics;
+﻿using Microsoft.Xna.Framework.Graphics;
 
 namespace DuckGame
 {

--- a/DuckGame/src/MonoTime/Smartness/AI.cs
+++ b/DuckGame/src/MonoTime/Smartness/AI.cs
@@ -1,11 +1,4 @@
-﻿//// Decompiled with JetBrains decompiler
-//// Type: DuckGame.AI
-////removed for regex reasons Culture=neutral, PublicKeyToken=null
-//// MVID: C907F20B-C12B-4773-9B1E-25290117C0E4
-//// Assembly location: D:\Program Files (x86)\Steam\steamapps\common\Duck Game\DuckGame.exe
-//// XML documentation location: D:\Program Files (x86)\Steam\steamapps\common\Duck Game\DuckGame.xml
-
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.Linq;
 
 namespace DuckGame

--- a/DuckGame/src/MonoTime/Sound/NAudio/MainFilterProvider.cs
+++ b/DuckGame/src/MonoTime/Sound/NAudio/MainFilterProvider.cs
@@ -1,11 +1,4 @@
-﻿//// Decompiled with JetBrains decompiler
-//// Type: DuckGame.MainFilterProvider
-////removed for regex reasons Culture=neutral, PublicKeyToken=null
-//// MVID: C907F20B-C12B-4773-9B1E-25290117C0E4
-//// Assembly location: D:\Program Files (x86)\Steam\steamapps\common\Duck Game\DuckGame.exe
-//// XML documentation location: D:\Program Files (x86)\Steam\steamapps\common\Duck Game\DuckGame.xml
-
-//using NAudio.Dsp;
+﻿//using NAudio.Dsp;
 //using NAudio.Wave;
 
 //namespace DuckGame

--- a/DuckGame/src/MonoTime/Sound/NAudio/Midi.cs
+++ b/DuckGame/src/MonoTime/Sound/NAudio/Midi.cs
@@ -1,11 +1,4 @@
-﻿//// Decompiled with JetBrains decompiler
-//// Type: DuckGame.Midi
-////removed for regex reasons Culture=neutral, PublicKeyToken=null
-//// MVID: C907F20B-C12B-4773-9B1E-25290117C0E4
-//// Assembly location: D:\Program Files (x86)\Steam\steamapps\common\Duck Game\DuckGame.exe
-//// XML documentation location: D:\Program Files (x86)\Steam\steamapps\common\Duck Game\DuckGame.xml
-
-//using NAudio.Midi;
+﻿//using NAudio.Midi;
 //using System;
 
 //namespace DuckGame

--- a/DuckGame/src/MonoTime/Sound/Retro/VGMSong.cs
+++ b/DuckGame/src/MonoTime/Sound/Retro/VGMSong.cs
@@ -1,11 +1,4 @@
-﻿// Decompiled with JetBrains decompiler
-// Type: DuckGame.VGMSong
-//removed for regex reasons Culture=neutral, PublicKeyToken=null
-// MVID: C907F20B-C12B-4773-9B1E-25290117C0E4
-// Assembly location: D:\Program Files (x86)\Steam\steamapps\common\Duck Game\DuckGame.exe
-// XML documentation location: D:\Program Files (x86)\Steam\steamapps\common\Duck Game\DuckGame.xml
-
-using Microsoft.Xna.Framework.Audio;
+﻿using Microsoft.Xna.Framework.Audio;
 using System;
 using System.IO;
 using System.IO.Compression;

--- a/DuckGame/src/MonoTime/Sound/Retro/YM2612.cs
+++ b/DuckGame/src/MonoTime/Sound/Retro/YM2612.cs
@@ -1,11 +1,4 @@
-﻿// Decompiled with JetBrains decompiler
-// Type: DuckGame.YM2612
-//removed for regex reasons Culture=neutral, PublicKeyToken=null
-// MVID: C907F20B-C12B-4773-9B1E-25290117C0E4
-// Assembly location: D:\Program Files (x86)\Steam\steamapps\common\Duck Game\DuckGame.exe
-// XML documentation location: D:\Program Files (x86)\Steam\steamapps\common\Duck Game\DuckGame.xml
-
-namespace DuckGame
+﻿namespace DuckGame
 {
     public class YM2612
     {

--- a/DuckGame/src/MonoTime/Sound/SFX.cs
+++ b/DuckGame/src/MonoTime/Sound/SFX.cs
@@ -1,11 +1,4 @@
-﻿// Decompiled with JetBrains decompiler
-// Type: DuckGame.SFX
-//removed for regex reasons Culture=neutral, PublicKeyToken=null
-// MVID: C907F20B-C12B-4773-9B1E-25290117C0E4
-// Assembly location: D:\Program Files (x86)\Steam\steamapps\common\Duck Game\DuckGame.exe
-// XML documentation location: D:\Program Files (x86)\Steam\steamapps\common\Duck Game\DuckGame.xml
-
-using Microsoft.Xna.Framework.Audio;
+﻿using Microsoft.Xna.Framework.Audio;
 using System;
 using System.Collections.Generic;
 using System.Linq;

--- a/DuckGame/src/MonoTime/Sound/Song.cs
+++ b/DuckGame/src/MonoTime/Sound/Song.cs
@@ -1,11 +1,4 @@
-﻿// Decompiled with JetBrains decompiler
-// Type: DuckGame.Song
-//removed for regex reasons Culture=neutral, PublicKeyToken=null
-// MVID: C907F20B-C12B-4773-9B1E-25290117C0E4
-// Assembly location: D:\Program Files (x86)\Steam\steamapps\common\Duck Game\DuckGame.exe
-// XML documentation location: D:\Program Files (x86)\Steam\steamapps\common\Duck Game\DuckGame.xml
-
-using System.IO;
+﻿using System.IO;
 
 namespace DuckGame
 {

--- a/DuckGame/src/MonoTime/Sound/Sound.cs
+++ b/DuckGame/src/MonoTime/Sound/Sound.cs
@@ -1,11 +1,4 @@
-﻿// Decompiled with JetBrains decompiler
-// Type: DuckGame.Sound
-//removed for regex reasons Culture=neutral, PublicKeyToken=null
-// MVID: C907F20B-C12B-4773-9B1E-25290117C0E4
-// Assembly location: D:\Program Files (x86)\Steam\steamapps\common\Duck Game\DuckGame.exe
-// XML documentation location: D:\Program Files (x86)\Steam\steamapps\common\Duck Game\DuckGame.xml
-
-using Microsoft.Xna.Framework.Audio;
+﻿using Microsoft.Xna.Framework.Audio;
 using System;
 
 namespace DuckGame

--- a/DuckGame/src/MonoTime/Sound/Speech.cs
+++ b/DuckGame/src/MonoTime/Sound/Speech.cs
@@ -1,11 +1,4 @@
-﻿// Decompiled with JetBrains decompiler
-// Type: DuckGame.Speech
-//removed for regex reasons Culture=neutral, PublicKeyToken=null
-// MVID: C907F20B-C12B-4773-9B1E-25290117C0E4
-// Assembly location: D:\Program Files (x86)\Steam\steamapps\common\Duck Game\DuckGame.exe
-// XML documentation location: D:\Program Files (x86)\Steam\steamapps\common\Duck Game\DuckGame.xml
-
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Speech.Synthesis;

--- a/DuckGame/src/MonoTime/Sound/WavFile.cs
+++ b/DuckGame/src/MonoTime/Sound/WavFile.cs
@@ -1,11 +1,4 @@
-﻿// Decompiled with JetBrains decompiler
-// Type: DuckGame.WavFile
-//removed for regex reasons Culture=neutral, PublicKeyToken=null
-// MVID: C907F20B-C12B-4773-9B1E-25290117C0E4
-// Assembly location: D:\Program Files (x86)\Steam\steamapps\common\Duck Game\DuckGame.exe
-// XML documentation location: D:\Program Files (x86)\Steam\steamapps\common\Duck Game\DuckGame.xml
-
-using System.IO;
+﻿using System.IO;
 
 namespace DuckGame
 {

--- a/DuckGame/src/MonoTime/UI/UIDivider.cs
+++ b/DuckGame/src/MonoTime/UI/UIDivider.cs
@@ -1,11 +1,4 @@
-﻿// Decompiled with JetBrains decompiler
-// Type: DuckGame.UIDivider
-//removed for regex reasons Culture=neutral, PublicKeyToken=null
-// MVID: C907F20B-C12B-4773-9B1E-25290117C0E4
-// Assembly location: D:\Program Files (x86)\Steam\steamapps\common\Duck Game\DuckGame.exe
-// XML documentation location: D:\Program Files (x86)\Steam\steamapps\common\Duck Game\DuckGame.xml
-
-using System;
+﻿using System;
 
 namespace DuckGame
 {

--- a/DuckGame/src/MonoTime/UI/UIMatchmakingBox.cs
+++ b/DuckGame/src/MonoTime/UI/UIMatchmakingBox.cs
@@ -1,11 +1,4 @@
-﻿// Decompiled with JetBrains decompiler
-// Type: DuckGame.UIMatchmakingBox
-//removed for regex reasons Culture=neutral, PublicKeyToken=null
-// MVID: C907F20B-C12B-4773-9B1E-25290117C0E4
-// Assembly location: D:\Program Files (x86)\Steam\steamapps\common\Duck Game\DuckGame.exe
-// XML documentation location: D:\Program Files (x86)\Steam\steamapps\common\Duck Game\DuckGame.xml
-
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Linq;
 

--- a/DuckGame/src/XnaToFna/Application.cs
+++ b/DuckGame/src/XnaToFna/Application.cs
@@ -1,10 +1,4 @@
-﻿// Decompiled with JetBrains decompiler
-// Type: XnaToFna.ProxyForms.Application
-// Assembly: XnaToFna, Version=18.5.1.29483, Culture=neutral, PublicKeyToken=null
-// MVID: C1D3521D-C7E9-4C43-B430-D28CC69450A3
-// Assembly location: C:\Users\daniel\Desktop\Release\XnaToFna.exe
-
-using System.Reflection;
+﻿using System.Reflection;
 using System.Threading;
 
 namespace XnaToFna.ProxyForms

--- a/DuckGame/src/XnaToFna/AvatarExpression.cs
+++ b/DuckGame/src/XnaToFna/AvatarExpression.cs
@@ -1,10 +1,4 @@
-﻿// Decompiled with JetBrains decompiler
-// Type: XnaToFna.StubXDK.GamerServices.AvatarExpression
-// Assembly: XnaToFna, Version=18.5.1.29483, Culture=neutral, PublicKeyToken=null
-// MVID: C1D3521D-C7E9-4C43-B430-D28CC69450A3
-// Assembly location: C:\Users\daniel\Desktop\Release\XnaToFna.exe
-
-namespace XnaToFna.StubXDK.GamerServices
+﻿namespace XnaToFna.StubXDK.GamerServices
 {
     public struct AvatarExpression
     {

--- a/DuckGame/src/XnaToFna/AvatarEye.cs
+++ b/DuckGame/src/XnaToFna/AvatarEye.cs
@@ -1,10 +1,4 @@
-﻿// Decompiled with JetBrains decompiler
-// Type: XnaToFna.StubXDK.GamerServices.AvatarEye
-// Assembly: XnaToFna, Version=18.5.1.29483, Culture=neutral, PublicKeyToken=null
-// MVID: C1D3521D-C7E9-4C43-B430-D28CC69450A3
-// Assembly location: C:\Users\daniel\Desktop\Release\XnaToFna.exe
-
-namespace XnaToFna.StubXDK.GamerServices
+﻿namespace XnaToFna.StubXDK.GamerServices
 {
     public enum AvatarEye
     {

--- a/DuckGame/src/XnaToFna/AvatarEyebrow.cs
+++ b/DuckGame/src/XnaToFna/AvatarEyebrow.cs
@@ -1,10 +1,4 @@
-﻿// Decompiled with JetBrains decompiler
-// Type: XnaToFna.StubXDK.GamerServices.AvatarEyebrow
-// Assembly: XnaToFna, Version=18.5.1.29483, Culture=neutral, PublicKeyToken=null
-// MVID: C1D3521D-C7E9-4C43-B430-D28CC69450A3
-// Assembly location: C:\Users\daniel\Desktop\Release\XnaToFna.exe
-
-namespace XnaToFna.StubXDK.GamerServices
+﻿namespace XnaToFna.StubXDK.GamerServices
 {
     public enum AvatarEyebrow
     {

--- a/DuckGame/src/XnaToFna/AvatarMouth.cs
+++ b/DuckGame/src/XnaToFna/AvatarMouth.cs
@@ -1,10 +1,4 @@
-﻿// Decompiled with JetBrains decompiler
-// Type: XnaToFna.StubXDK.GamerServices.AvatarMouth
-// Assembly: XnaToFna, Version=18.5.1.29483, Culture=neutral, PublicKeyToken=null
-// MVID: C1D3521D-C7E9-4C43-B430-D28CC69450A3
-// Assembly location: C:\Users\daniel\Desktop\Release\XnaToFna.exe
-
-namespace XnaToFna.StubXDK.GamerServices
+﻿namespace XnaToFna.StubXDK.GamerServices
 {
     public enum AvatarMouth
     {

--- a/DuckGame/src/XnaToFna/BinaryFormatterHelper.cs
+++ b/DuckGame/src/XnaToFna/BinaryFormatterHelper.cs
@@ -1,10 +1,4 @@
-﻿// Decompiled with JetBrains decompiler
-// Type: XnaToFna.BinaryFormatterHelper
-// Assembly: XnaToFna, Version=18.5.1.29483, Culture=neutral, PublicKeyToken=null
-// MVID: C1D3521D-C7E9-4C43-B430-D28CC69450A3
-// Assembly location: C:\Users\daniel\Desktop\Release\XnaToFna.exe
-
-using Microsoft.Xna.Framework;
+﻿using Microsoft.Xna.Framework;
 using System;
 using System.Reflection;
 using System.Runtime.Serialization;

--- a/DuckGame/src/XnaToFna/CloseReason.cs
+++ b/DuckGame/src/XnaToFna/CloseReason.cs
@@ -1,10 +1,4 @@
-﻿// Decompiled with JetBrains decompiler
-// Type: XnaToFna.ProxyForms.CloseReason
-// Assembly: XnaToFna, Version=18.5.1.29483, Culture=neutral, PublicKeyToken=null
-// MVID: C1D3521D-C7E9-4C43-B430-D28CC69450A3
-// Assembly location: C:\Users\daniel\Desktop\Release\XnaToFna.exe
-
-namespace XnaToFna.ProxyForms
+﻿namespace XnaToFna.ProxyForms
 {
     public enum CloseReason
     {

--- a/DuckGame/src/XnaToFna/ConsoleRegion.cs
+++ b/DuckGame/src/XnaToFna/ConsoleRegion.cs
@@ -1,10 +1,4 @@
-﻿// Decompiled with JetBrains decompiler
-// Type: XnaToFna.StubXDK.GamerServices.ConsoleRegion
-// Assembly: XnaToFna, Version=18.5.1.29483, Culture=neutral, PublicKeyToken=null
-// MVID: C1D3521D-C7E9-4C43-B430-D28CC69450A3
-// Assembly location: C:\Users\daniel\Desktop\Release\XnaToFna.exe
-
-namespace XnaToFna.StubXDK.GamerServices
+﻿namespace XnaToFna.StubXDK.GamerServices
 {
     public enum ConsoleRegion
     {

--- a/DuckGame/src/XnaToFna/ContentHelper.cs
+++ b/DuckGame/src/XnaToFna/ContentHelper.cs
@@ -1,10 +1,4 @@
-﻿//// Decompiled with JetBrains decompiler
-//// Type: XnaToFna.ContentHelper
-//// Assembly: XnaToFna, Version=18.5.1.29483, Culture=neutral, PublicKeyToken=null
-//// MVID: C1D3521D-C7E9-4C43-B430-D28CC69450A3
-//// Assembly location: C:\Users\daniel\Desktop\Release\XnaToFna.exe
-
-//using MonoMod.Utils;
+﻿//using MonoMod.Utils;
 //using System;
 //using System.Diagnostics;
 //using System.IO;

--- a/DuckGame/src/XnaToFna/ContentHelperGame.cs
+++ b/DuckGame/src/XnaToFna/ContentHelperGame.cs
@@ -1,10 +1,4 @@
-﻿// Decompiled with JetBrains decompiler
-// Type: XnaToFna.ContentHelperGame
-// Assembly: XnaToFna, Version=18.5.1.29483, Culture=neutral, PublicKeyToken=null
-// MVID: C1D3521D-C7E9-4C43-B430-D28CC69450A3
-// Assembly location: C:\Users\daniel\Desktop\Release\XnaToFna.exe
-
-using Microsoft.Xna.Framework;
+﻿using Microsoft.Xna.Framework;
 using System;
 using System.Collections.Generic;
 using System.Threading;

--- a/DuckGame/src/XnaToFna/Control.cs
+++ b/DuckGame/src/XnaToFna/Control.cs
@@ -1,10 +1,4 @@
-﻿// Decompiled with JetBrains decompiler
-// Type: XnaToFna.ProxyForms.Control
-// Assembly: XnaToFna, Version=18.5.1.29483, Culture=neutral, PublicKeyToken=null
-// MVID: C1D3521D-C7E9-4C43-B430-D28CC69450A3
-// Assembly location: C:\Users\daniel\Desktop\Release\XnaToFna.exe
-
-using System;
+﻿using System;
 using System.Collections.Generic;
 using XnaToFna.ProxyDrawing;
 

--- a/DuckGame/src/XnaToFna/CopyingStream.cs
+++ b/DuckGame/src/XnaToFna/CopyingStream.cs
@@ -1,10 +1,4 @@
-﻿// Decompiled with JetBrains decompiler
-// Type: XnaToFna.CopyingStream
-// Assembly: XnaToFna, Version=18.5.1.29483, Culture=neutral, PublicKeyToken=null
-// MVID: C1D3521D-C7E9-4C43-B430-D28CC69450A3
-// Assembly location: C:\Users\daniel\Desktop\Release\XnaToFna.exe
-
-using System.IO;
+﻿using System.IO;
 
 namespace XnaToFna
 {

--- a/DuckGame/src/XnaToFna/Cursor.cs
+++ b/DuckGame/src/XnaToFna/Cursor.cs
@@ -1,10 +1,4 @@
-﻿// Decompiled with JetBrains decompiler
-// Type: XnaToFna.ProxyForms.Cursor
-// Assembly: XnaToFna, Version=18.5.1.29483, Culture=neutral, PublicKeyToken=null
-// MVID: C1D3521D-C7E9-4C43-B430-D28CC69450A3
-// Assembly location: C:\Users\daniel\Desktop\Release\XnaToFna.exe
-
-using Microsoft.Xna.Framework.Input;
+﻿using Microsoft.Xna.Framework.Input;
 using System;
 using System.Collections.Generic;
 using System.IO;

--- a/DuckGame/src/XnaToFna/DInput.cs
+++ b/DuckGame/src/XnaToFna/DInput.cs
@@ -1,10 +1,4 @@
-﻿// Decompiled with JetBrains decompiler
-// Type: XnaToFna.ProxyDInput.DInput
-// Assembly: XnaToFna, Version=18.5.1.29483, Culture=neutral, PublicKeyToken=null
-// MVID: C1D3521D-C7E9-4C43-B430-D28CC69450A3
-// Assembly location: C:\Users\daniel\Desktop\Release\XnaToFna.exe
-
-using Microsoft.Xna.Framework;
+﻿using Microsoft.Xna.Framework;
 using Microsoft.Xna.Framework.Input;
 using System;
 using System.Collections.Generic;

--- a/DuckGame/src/XnaToFna/DInputState.cs
+++ b/DuckGame/src/XnaToFna/DInputState.cs
@@ -1,10 +1,4 @@
-﻿// Decompiled with JetBrains decompiler
-// Type: XnaToFna.ProxyDInput.DInputState
-// Assembly: XnaToFna, Version=18.5.1.29483, Culture=neutral, PublicKeyToken=null
-// MVID: C1D3521D-C7E9-4C43-B430-D28CC69450A3
-// Assembly location: C:\Users\daniel\Desktop\Release\XnaToFna.exe
-
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 
 namespace XnaToFna.ProxyDInput
 {

--- a/DuckGame/src/XnaToFna/DeviceEvents.cs
+++ b/DuckGame/src/XnaToFna/DeviceEvents.cs
@@ -1,10 +1,4 @@
-﻿// Decompiled with JetBrains decompiler
-// Type: XnaToFna.DeviceEvents
-// Assembly: XnaToFna, Version=18.5.1.29483, Culture=neutral, PublicKeyToken=null
-// MVID: C1D3521D-C7E9-4C43-B430-D28CC69450A3
-// Assembly location: C:\Users\daniel\Desktop\Release\XnaToFna.exe
-
-using Microsoft.Xna.Framework;
+﻿using Microsoft.Xna.Framework;
 using Microsoft.Xna.Framework.Input;
 using System;
 using XnaToFna.ProxyForms;

--- a/DuckGame/src/XnaToFna/EffectTransformer.cs
+++ b/DuckGame/src/XnaToFna/EffectTransformer.cs
@@ -1,10 +1,4 @@
-﻿// Decompiled with JetBrains decompiler
-// Type: XnaToFna.ContentTransformers.EffectTransformer
-// Assembly: XnaToFna, Version=18.5.1.29483, Culture=neutral, PublicKeyToken=null
-// MVID: C1D3521D-C7E9-4C43-B430-D28CC69450A3
-// Assembly location: C:\Users\daniel\Desktop\Release\XnaToFna.exe
-
-using Microsoft.Xna.Framework.Content;
+﻿using Microsoft.Xna.Framework.Content;
 using Microsoft.Xna.Framework.Graphics;
 using System;
 using System.Runtime.Serialization;

--- a/DuckGame/src/XnaToFna/FNAHooks.cs
+++ b/DuckGame/src/XnaToFna/FNAHooks.cs
@@ -1,10 +1,4 @@
-﻿// Decompiled with JetBrains decompiler
-// Type: XnaToFna.FNAHooks
-// Assembly: XnaToFna, Version=18.5.1.29483, Culture=neutral, PublicKeyToken=null
-// MVID: C1D3521D-C7E9-4C43-B430-D28CC69450A3
-// Assembly location: C:\Users\daniel\Desktop\Release\XnaToFna.exe
-
-using Microsoft.Xna.Framework.Content;
+﻿using Microsoft.Xna.Framework.Content;
 using Microsoft.Xna.Framework.Graphics;
 using System;
 using System.Collections.Generic;

--- a/DuckGame/src/XnaToFna/FakeMonitor.cs
+++ b/DuckGame/src/XnaToFna/FakeMonitor.cs
@@ -1,10 +1,4 @@
-﻿// Decompiled with JetBrains decompiler
-// Type: XnaToFna.FakeMonitor
-// Assembly: XnaToFna, Version=18.5.1.29483, Culture=neutral, PublicKeyToken=null
-// MVID: C1D3521D-C7E9-4C43-B430-D28CC69450A3
-// Assembly location: C:\Users\daniel\Desktop\Release\XnaToFna.exe
-
-namespace XnaToFna
+﻿namespace XnaToFna
 {
     public static class FakeMonitor
     {

--- a/DuckGame/src/XnaToFna/FieldInfoHelper.cs
+++ b/DuckGame/src/XnaToFna/FieldInfoHelper.cs
@@ -1,10 +1,4 @@
-﻿// Decompiled with JetBrains decompiler
-// Type: XnaToFna.ProxyReflection.FieldInfoHelper
-// Assembly: XnaToFna, Version=18.5.1.29483, Culture=neutral, PublicKeyToken=null
-// MVID: C1D3521D-C7E9-4C43-B430-D28CC69450A3
-// Assembly location: C:\Users\daniel\Desktop\Release\XnaToFna.exe
-
-using DuckGame;
+﻿using DuckGame;
 using System;
 using System.Collections.Generic;
 using System.Globalization;

--- a/DuckGame/src/XnaToFna/FileSystemHelper.cs
+++ b/DuckGame/src/XnaToFna/FileSystemHelper.cs
@@ -1,10 +1,4 @@
-﻿// Decompiled with JetBrains decompiler
-// Type: XnaToFna.FileSystemHelper
-// Assembly: XnaToFna, Version=18.5.1.29483, Culture=neutral, PublicKeyToken=null
-// MVID: C1D3521D-C7E9-4C43-B430-D28CC69450A3
-// Assembly location: C:\Users\daniel\Desktop\Release\XnaToFna.exe
-
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Text;

--- a/DuckGame/src/XnaToFna/FindServicesCompletedArgs.cs
+++ b/DuckGame/src/XnaToFna/FindServicesCompletedArgs.cs
@@ -1,10 +1,4 @@
-﻿// Decompiled with JetBrains decompiler
-// Type: XnaToFna.StubXDK.GamerServices.FindServicesCompletedArgs
-// Assembly: XnaToFna, Version=18.5.1.29483, Culture=neutral, PublicKeyToken=null
-// MVID: C1D3521D-C7E9-4C43-B430-D28CC69450A3
-// Assembly location: C:\Users\daniel\Desktop\Release\XnaToFna.exe
-
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
 

--- a/DuckGame/src/XnaToFna/ForcedStreamContentManager.cs
+++ b/DuckGame/src/XnaToFna/ForcedStreamContentManager.cs
@@ -1,10 +1,4 @@
-﻿// Decompiled with JetBrains decompiler
-// Type: XnaToFna.ForcedStreamContentManager
-// Assembly: XnaToFna, Version=18.5.1.29483, Culture=neutral, PublicKeyToken=null
-// MVID: C1D3521D-C7E9-4C43-B430-D28CC69450A3
-// Assembly location: C:\Users\daniel\Desktop\Release\XnaToFna.exe
-
-using Microsoft.Xna.Framework.Content;
+﻿using Microsoft.Xna.Framework.Content;
 using System;
 using System.IO;
 

--- a/DuckGame/src/XnaToFna/Form.cs
+++ b/DuckGame/src/XnaToFna/Form.cs
@@ -1,10 +1,4 @@
-﻿// Decompiled with JetBrains decompiler
-// Type: XnaToFna.ProxyForms.Form
-// Assembly: XnaToFna, Version=18.5.1.29483, Culture=neutral, PublicKeyToken=null
-// MVID: C1D3521D-C7E9-4C43-B430-D28CC69450A3
-// Assembly location: C:\Users\daniel\Desktop\Release\XnaToFna.exe
-
-using System;
+﻿using System;
 using System.Threading;
 
 namespace XnaToFna.ProxyForms

--- a/DuckGame/src/XnaToFna/FormBorderStyle.cs
+++ b/DuckGame/src/XnaToFna/FormBorderStyle.cs
@@ -1,10 +1,4 @@
-﻿// Decompiled with JetBrains decompiler
-// Type: XnaToFna.ProxyForms.FormBorderStyle
-// Assembly: XnaToFna, Version=18.5.1.29483, Culture=neutral, PublicKeyToken=null
-// MVID: C1D3521D-C7E9-4C43-B430-D28CC69450A3
-// Assembly location: C:\Users\daniel\Desktop\Release\XnaToFna.exe
-
-namespace XnaToFna.ProxyForms
+﻿namespace XnaToFna.ProxyForms
 {
     public enum FormBorderStyle
     {

--- a/DuckGame/src/XnaToFna/FormClosedEventArgs.cs
+++ b/DuckGame/src/XnaToFna/FormClosedEventArgs.cs
@@ -1,10 +1,4 @@
-﻿// Decompiled with JetBrains decompiler
-// Type: XnaToFna.ProxyForms.FormClosedEventArgs
-// Assembly: XnaToFna, Version=18.5.1.29483, Culture=neutral, PublicKeyToken=null
-// MVID: C1D3521D-C7E9-4C43-B430-D28CC69450A3
-// Assembly location: C:\Users\daniel\Desktop\Release\XnaToFna.exe
-
-using System.ComponentModel;
+﻿using System.ComponentModel;
 
 namespace XnaToFna.ProxyForms
 {

--- a/DuckGame/src/XnaToFna/FormClosedEventHandler.cs
+++ b/DuckGame/src/XnaToFna/FormClosedEventHandler.cs
@@ -1,10 +1,4 @@
-﻿// Decompiled with JetBrains decompiler
-// Type: XnaToFna.ProxyForms.FormClosedEventHandler
-// Assembly: XnaToFna, Version=18.5.1.29483, Culture=neutral, PublicKeyToken=null
-// MVID: C1D3521D-C7E9-4C43-B430-D28CC69450A3
-// Assembly location: C:\Users\daniel\Desktop\Release\XnaToFna.exe
-
-namespace XnaToFna.ProxyForms
+﻿namespace XnaToFna.ProxyForms
 {
     public delegate void FormClosedEventHandler(object sender, FormClosedEventArgs e);
 }

--- a/DuckGame/src/XnaToFna/FormClosingEventArgs.cs
+++ b/DuckGame/src/XnaToFna/FormClosingEventArgs.cs
@@ -1,10 +1,4 @@
-﻿// Decompiled with JetBrains decompiler
-// Type: XnaToFna.ProxyForms.FormClosingEventArgs
-// Assembly: XnaToFna, Version=18.5.1.29483, Culture=neutral, PublicKeyToken=null
-// MVID: C1D3521D-C7E9-4C43-B430-D28CC69450A3
-// Assembly location: C:\Users\daniel\Desktop\Release\XnaToFna.exe
-
-using System.ComponentModel;
+﻿using System.ComponentModel;
 
 namespace XnaToFna.ProxyForms
 {

--- a/DuckGame/src/XnaToFna/FormClosingEventHandler.cs
+++ b/DuckGame/src/XnaToFna/FormClosingEventHandler.cs
@@ -1,10 +1,4 @@
-﻿// Decompiled with JetBrains decompiler
-// Type: XnaToFna.ProxyForms.FormClosingEventHandler
-// Assembly: XnaToFna, Version=18.5.1.29483, Culture=neutral, PublicKeyToken=null
-// MVID: C1D3521D-C7E9-4C43-B430-D28CC69450A3
-// Assembly location: C:\Users\daniel\Desktop\Release\XnaToFna.exe
-
-namespace XnaToFna.ProxyForms
+﻿namespace XnaToFna.ProxyForms
 {
     public delegate void FormClosingEventHandler(object sender, FormClosingEventArgs e);
 }

--- a/DuckGame/src/XnaToFna/FormStartPosition.cs
+++ b/DuckGame/src/XnaToFna/FormStartPosition.cs
@@ -1,10 +1,4 @@
-﻿// Decompiled with JetBrains decompiler
-// Type: XnaToFna.ProxyForms.FormStartPosition
-// Assembly: XnaToFna, Version=18.5.1.29483, Culture=neutral, PublicKeyToken=null
-// MVID: C1D3521D-C7E9-4C43-B430-D28CC69450A3
-// Assembly location: C:\Users\daniel\Desktop\Release\XnaToFna.exe
-
-namespace XnaToFna.ProxyForms
+﻿namespace XnaToFna.ProxyForms
 {
     public enum FormStartPosition
     {

--- a/DuckGame/src/XnaToFna/FormWindowState.cs
+++ b/DuckGame/src/XnaToFna/FormWindowState.cs
@@ -1,10 +1,4 @@
-﻿// Decompiled with JetBrains decompiler
-// Type: XnaToFna.ProxyForms.FormWindowState
-// Assembly: XnaToFna, Version=18.5.1.29483, Culture=neutral, PublicKeyToken=null
-// MVID: C1D3521D-C7E9-4C43-B430-D28CC69450A3
-// Assembly location: C:\Users\daniel\Desktop\Release\XnaToFna.exe
-
-namespace XnaToFna.ProxyForms
+﻿namespace XnaToFna.ProxyForms
 {
     public enum FormWindowState
     {

--- a/DuckGame/src/XnaToFna/GZipContentReader`1.cs
+++ b/DuckGame/src/XnaToFna/GZipContentReader`1.cs
@@ -1,10 +1,4 @@
-﻿// Decompiled with JetBrains decompiler
-// Type: XnaToFna.ContentTransformers.GZipContentReader`1
-// Assembly: XnaToFna, Version=18.5.1.29483, Culture=neutral, PublicKeyToken=null
-// MVID: C1D3521D-C7E9-4C43-B430-D28CC69450A3
-// Assembly location: C:\Users\daniel\Desktop\Release\XnaToFna.exe
-
-using Microsoft.Xna.Framework.Content;
+﻿using Microsoft.Xna.Framework.Content;
 using System.IO.Compression;
 
 namespace XnaToFna.ContentTransformers

--- a/DuckGame/src/XnaToFna/GameForm.cs
+++ b/DuckGame/src/XnaToFna/GameForm.cs
@@ -1,10 +1,4 @@
-﻿// Decompiled with JetBrains decompiler
-// Type: XnaToFna.ProxyForms.GameForm
-// Assembly: XnaToFna, Version=18.5.1.29483, Culture=neutral, PublicKeyToken=null
-// MVID: C1D3521D-C7E9-4C43-B430-D28CC69450A3
-// Assembly location: C:\Users\daniel\Desktop\Release\XnaToFna.exe
-
-using Microsoft.Xna.Framework;
+﻿using Microsoft.Xna.Framework;
 using Microsoft.Xna.Framework.Graphics;
 using SDL2;
 using System;

--- a/DuckGame/src/XnaToFna/GamerExtensions.cs
+++ b/DuckGame/src/XnaToFna/GamerExtensions.cs
@@ -1,10 +1,4 @@
-﻿// Decompiled with JetBrains decompiler
-// Type: XnaToFna.StubXDK.GamerServices.GamerExtensions
-// Assembly: XnaToFna, Version=18.5.1.29483, Culture=neutral, PublicKeyToken=null
-// MVID: C1D3521D-C7E9-4C43-B430-D28CC69450A3
-// Assembly location: C:\Users\daniel\Desktop\Release\XnaToFna.exe
-
-using MonoMod;
+﻿using MonoMod;
 
 namespace XnaToFna.StubXDK.GamerServices
 {

--- a/DuckGame/src/XnaToFna/GamerPresenceExtensions.cs
+++ b/DuckGame/src/XnaToFna/GamerPresenceExtensions.cs
@@ -1,10 +1,4 @@
-﻿// Decompiled with JetBrains decompiler
-// Type: XnaToFna.StubXDK.GamerServices.GamerPresenceExtensions
-// Assembly: XnaToFna, Version=18.5.1.29483, Culture=neutral, PublicKeyToken=null
-// MVID: C1D3521D-C7E9-4C43-B430-D28CC69450A3
-// Assembly location: C:\Users\daniel\Desktop\Release\XnaToFna.exe
-
-using MonoMod;
+﻿using MonoMod;
 using System;
 using System.Collections.Generic;
 using System.Reflection;

--- a/DuckGame/src/XnaToFna/GuideExtensions.cs
+++ b/DuckGame/src/XnaToFna/GuideExtensions.cs
@@ -1,10 +1,4 @@
-﻿// Decompiled with JetBrains decompiler
-// Type: XnaToFna.StubXDK.GamerServices.GuideExtensions
-// Assembly: XnaToFna, Version=18.5.1.29483, Culture=neutral, PublicKeyToken=null
-// MVID: C1D3521D-C7E9-4C43-B430-D28CC69450A3
-// Assembly location: C:\Users\daniel\Desktop\Release\XnaToFna.exe
-
-using Microsoft.Xna.Framework;
+﻿using Microsoft.Xna.Framework;
 
 namespace XnaToFna.StubXDK.GamerServices
 {

--- a/DuckGame/src/XnaToFna/HookProc.cs
+++ b/DuckGame/src/XnaToFna/HookProc.cs
@@ -1,10 +1,4 @@
-﻿// Decompiled with JetBrains decompiler
-// Type: XnaToFna.HookProc
-// Assembly: XnaToFna, Version=18.5.1.29483, Culture=neutral, PublicKeyToken=null
-// MVID: C1D3521D-C7E9-4C43-B430-D28CC69450A3
-// Assembly location: C:\Users\daniel\Desktop\Release\XnaToFna.exe
-
-using System;
+﻿using System;
 
 namespace XnaToFna
 {

--- a/DuckGame/src/XnaToFna/HookType.cs
+++ b/DuckGame/src/XnaToFna/HookType.cs
@@ -1,10 +1,4 @@
-﻿// Decompiled with JetBrains decompiler
-// Type: XnaToFna.ProxyForms.HookType
-// Assembly: XnaToFna, Version=18.5.1.29483, Culture=neutral, PublicKeyToken=null
-// MVID: C1D3521D-C7E9-4C43-B430-D28CC69450A3
-// Assembly location: C:\Users\daniel\Desktop\Release\XnaToFna.exe
-
-namespace XnaToFna.ProxyForms
+﻿namespace XnaToFna.ProxyForms
 {
     public enum HookType
     {

--- a/DuckGame/src/XnaToFna/IAvatarAnimation.cs
+++ b/DuckGame/src/XnaToFna/IAvatarAnimation.cs
@@ -1,10 +1,4 @@
-﻿// Decompiled with JetBrains decompiler
-// Type: XnaToFna.StubXDK.GamerServices.IAvatarAnimation
-// Assembly: XnaToFna, Version=18.5.1.29483, Culture=neutral, PublicKeyToken=null
-// MVID: C1D3521D-C7E9-4C43-B430-D28CC69450A3
-// Assembly location: C:\Users\daniel\Desktop\Release\XnaToFna.exe
-
-using Microsoft.Xna.Framework;
+﻿using Microsoft.Xna.Framework;
 using System;
 using System.Collections.ObjectModel;
 

--- a/DuckGame/src/XnaToFna/ILPlatform.cs
+++ b/DuckGame/src/XnaToFna/ILPlatform.cs
@@ -1,10 +1,4 @@
-﻿// Decompiled with JetBrains decompiler
-// Type: XnaToFna.ILPlatform
-// Assembly: XnaToFna, Version=18.5.1.29483, Culture=neutral, PublicKeyToken=null
-// MVID: C1D3521D-C7E9-4C43-B430-D28CC69450A3
-// Assembly location: C:\Users\daniel\Desktop\Release\XnaToFna.exe
-
-namespace XnaToFna
+﻿namespace XnaToFna
 {
     public enum ILPlatform
     {

--- a/DuckGame/src/XnaToFna/KeyboardEvents.cs
+++ b/DuckGame/src/XnaToFna/KeyboardEvents.cs
@@ -1,10 +1,4 @@
-﻿// Decompiled with JetBrains decompiler
-// Type: XnaToFna.KeyboardEvents
-// Assembly: XnaToFna, Version=18.5.1.29483, Culture=neutral, PublicKeyToken=null
-// MVID: C1D3521D-C7E9-4C43-B430-D28CC69450A3
-// Assembly location: C:\Users\daniel\Desktop\Release\XnaToFna.exe
-
-using Microsoft.Xna.Framework.Input;
+﻿using Microsoft.Xna.Framework.Input;
 using System;
 using System.Collections.Generic;
 using XnaToFna.ProxyForms;

--- a/DuckGame/src/XnaToFna/LeaderboardEntryExtensions.cs
+++ b/DuckGame/src/XnaToFna/LeaderboardEntryExtensions.cs
@@ -1,10 +1,4 @@
-﻿// Decompiled with JetBrains decompiler
-// Type: XnaToFna.StubXDK.GamerServices.LeaderboardEntryExtensions
-// Assembly: XnaToFna, Version=18.5.1.29483, Culture=neutral, PublicKeyToken=null
-// MVID: C1D3521D-C7E9-4C43-B430-D28CC69450A3
-// Assembly location: C:\Users\daniel\Desktop\Release\XnaToFna.exe
-
-using MonoMod;
+﻿using MonoMod;
 
 namespace XnaToFna.StubXDK.GamerServices
 {

--- a/DuckGame/src/XnaToFna/LeaderboardWriterExtensions.cs
+++ b/DuckGame/src/XnaToFna/LeaderboardWriterExtensions.cs
@@ -1,10 +1,4 @@
-﻿// Decompiled with JetBrains decompiler
-// Type: XnaToFna.StubXDK.GamerServices.LeaderboardWriterExtensions
-// Assembly: XnaToFna, Version=18.5.1.29483, Culture=neutral, PublicKeyToken=null
-// MVID: C1D3521D-C7E9-4C43-B430-D28CC69450A3
-// Assembly location: C:\Users\daniel\Desktop\Release\XnaToFna.exe
-
-using MonoMod;
+﻿using MonoMod;
 
 namespace XnaToFna.StubXDK.GamerServices
 {

--- a/DuckGame/src/XnaToFna/LzxDecoder.cs
+++ b/DuckGame/src/XnaToFna/LzxDecoder.cs
@@ -1,10 +1,4 @@
-﻿//// Decompiled with JetBrains decompiler
-//// Type: XnaToFna.LzxDecoder
-//// Assembly: XnaToFna, Version=18.5.1.29483, Culture=neutral, PublicKeyToken=null
-//// MVID: C1D3521D-C7E9-4C43-B430-D28CC69450A3
-//// Assembly location: C:\Users\daniel\Desktop\Release\XnaToFna.exe
-
-//using Microsoft.Xna.Framework;
+﻿//using Microsoft.Xna.Framework;
 //using MonoMod.Utils;
 //using System;
 //using System.IO;

--- a/DuckGame/src/XnaToFna/Message.cs
+++ b/DuckGame/src/XnaToFna/Message.cs
@@ -1,10 +1,4 @@
-﻿// Decompiled with JetBrains decompiler
-// Type: XnaToFna.ProxyForms.Message
-// Assembly: XnaToFna, Version=18.5.1.29483, Culture=neutral, PublicKeyToken=null
-// MVID: C1D3521D-C7E9-4C43-B430-D28CC69450A3
-// Assembly location: C:\Users\daniel\Desktop\Release\XnaToFna.exe
-
-using System;
+﻿using System;
 using System.Runtime.InteropServices;
 using System.Security;
 using System.Security.Permissions;

--- a/DuckGame/src/XnaToFna/Messages.cs
+++ b/DuckGame/src/XnaToFna/Messages.cs
@@ -1,10 +1,4 @@
-﻿// Decompiled with JetBrains decompiler
-// Type: XnaToFna.ProxyForms.Messages
-// Assembly: XnaToFna, Version=18.5.1.29483, Culture=neutral, PublicKeyToken=null
-// MVID: C1D3521D-C7E9-4C43-B430-D28CC69450A3
-// Assembly location: C:\Users\daniel\Desktop\Release\XnaToFna.exe
-
-namespace XnaToFna.ProxyForms
+﻿namespace XnaToFna.ProxyForms
 {
     public enum Messages
     {

--- a/DuckGame/src/XnaToFna/MethodInvoker.cs
+++ b/DuckGame/src/XnaToFna/MethodInvoker.cs
@@ -1,10 +1,4 @@
-﻿// Decompiled with JetBrains decompiler
-// Type: XnaToFna.ProxyForms.MethodInvoker
-// Assembly: XnaToFna, Version=18.5.1.29483, Culture=neutral, PublicKeyToken=null
-// MVID: C1D3521D-C7E9-4C43-B430-D28CC69450A3
-// Assembly location: C:\Users\daniel\Desktop\Release\XnaToFna.exe
-
-namespace XnaToFna.ProxyForms
+﻿namespace XnaToFna.ProxyForms
 {
     public delegate void MethodInvoker();
 }

--- a/DuckGame/src/XnaToFna/MouseButtons.cs
+++ b/DuckGame/src/XnaToFna/MouseButtons.cs
@@ -1,10 +1,4 @@
-﻿// Decompiled with JetBrains decompiler
-// Type: XnaToFna.ProxyForms.MouseButtons
-// Assembly: XnaToFna, Version=18.5.1.29483, Culture=neutral, PublicKeyToken=null
-// MVID: C1D3521D-C7E9-4C43-B430-D28CC69450A3
-// Assembly location: C:\Users\daniel\Desktop\Release\XnaToFna.exe
-
-using System;
+﻿using System;
 
 namespace XnaToFna.ProxyForms
 {

--- a/DuckGame/src/XnaToFna/MouseEventArgs.cs
+++ b/DuckGame/src/XnaToFna/MouseEventArgs.cs
@@ -1,10 +1,4 @@
-﻿// Decompiled with JetBrains decompiler
-// Type: XnaToFna.ProxyForms.MouseEventArgs
-// Assembly: XnaToFna, Version=18.5.1.29483, Culture=neutral, PublicKeyToken=null
-// MVID: C1D3521D-C7E9-4C43-B430-D28CC69450A3
-// Assembly location: C:\Users\daniel\Desktop\Release\XnaToFna.exe
-
-using System;
+﻿using System;
 
 namespace XnaToFna.ProxyForms
 {

--- a/DuckGame/src/XnaToFna/MouseEventHandler.cs
+++ b/DuckGame/src/XnaToFna/MouseEventHandler.cs
@@ -1,10 +1,4 @@
-﻿// Decompiled with JetBrains decompiler
-// Type: XnaToFna.ProxyForms.MouseEventHandler
-// Assembly: XnaToFna, Version=18.5.1.29483, Culture=neutral, PublicKeyToken=null
-// MVID: C1D3521D-C7E9-4C43-B430-D28CC69450A3
-// Assembly location: C:\Users\daniel\Desktop\Release\XnaToFna.exe
-
-namespace XnaToFna.ProxyForms
+﻿namespace XnaToFna.ProxyForms
 {
     public delegate void MouseEventHandler(object sender, MouseEventArgs e);
 }

--- a/DuckGame/src/XnaToFna/MouseEvents.cs
+++ b/DuckGame/src/XnaToFna/MouseEvents.cs
@@ -1,10 +1,4 @@
-﻿// Decompiled with JetBrains decompiler
-// Type: XnaToFna.MouseEvents
-// Assembly: XnaToFna, Version=18.5.1.29483, Culture=neutral, PublicKeyToken=null
-// MVID: C1D3521D-C7E9-4C43-B430-D28CC69450A3
-// Assembly location: C:\Users\daniel\Desktop\Release\XnaToFna.exe
-
-using Microsoft.Xna.Framework;
+﻿using Microsoft.Xna.Framework;
 using Microsoft.Xna.Framework.Input;
 using System;
 using XnaToFna.ProxyForms;

--- a/DuckGame/src/XnaToFna/NN.cs
+++ b/DuckGame/src/XnaToFna/NN.cs
@@ -1,10 +1,4 @@
-﻿// Decompiled with JetBrains decompiler
-// Type: XnaToFna.NN
-// Assembly: XnaToFna, Version=18.5.1.29483, Culture=neutral, PublicKeyToken=null
-// MVID: C1D3521D-C7E9-4C43-B430-D28CC69450A3
-// Assembly location: C:\Users\daniel\Desktop\Release\XnaToFna.exe
-
-using Mono.Cecil;
+﻿using Mono.Cecil;
 
 namespace XnaToFna
 {

--- a/DuckGame/src/XnaToFna/PInvoke.cs
+++ b/DuckGame/src/XnaToFna/PInvoke.cs
@@ -1,10 +1,4 @@
-﻿// Decompiled with JetBrains decompiler
-// Type: XnaToFna.PInvoke
-// Assembly: XnaToFna, Version=18.5.1.29483, Culture=neutral, PublicKeyToken=null
-// MVID: C1D3521D-C7E9-4C43-B430-D28CC69450A3
-// Assembly location: C:\Users\daniel\Desktop\Release\XnaToFna.exe
-
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Runtime.InteropServices;
 using System.Threading;

--- a/DuckGame/src/XnaToFna/PInvokeHelper.cs
+++ b/DuckGame/src/XnaToFna/PInvokeHelper.cs
@@ -1,10 +1,4 @@
-﻿// Decompiled with JetBrains decompiler
-// Type: XnaToFna.PInvokeHelper
-// Assembly: XnaToFna, Version=18.5.1.29483, Culture=neutral, PublicKeyToken=null
-// MVID: C1D3521D-C7E9-4C43-B430-D28CC69450A3
-// Assembly location: C:\Users\daniel\Desktop\Release\XnaToFna.exe
-
-using MonoMod.Utils;
+﻿using MonoMod.Utils;
 using System;
 using System.Runtime.InteropServices;
 

--- a/DuckGame/src/XnaToFna/PInvokeHooks.cs
+++ b/DuckGame/src/XnaToFna/PInvokeHooks.cs
@@ -1,10 +1,4 @@
-﻿// Decompiled with JetBrains decompiler
-// Type: XnaToFna.PInvokeHooks
-// Assembly: XnaToFna, Version=18.5.1.29483, Culture=neutral, PublicKeyToken=null
-// MVID: C1D3521D-C7E9-4C43-B430-D28CC69450A3
-// Assembly location: C:\Users\daniel\Desktop\Release\XnaToFna.exe
-
-using Microsoft.Xna.Framework;
+﻿using Microsoft.Xna.Framework;
 using Microsoft.Xna.Framework.Graphics;
 using Microsoft.Xna.Framework.Input;
 using SDL2;

--- a/DuckGame/src/XnaToFna/Point.cs
+++ b/DuckGame/src/XnaToFna/Point.cs
@@ -1,10 +1,4 @@
-﻿// Decompiled with JetBrains decompiler
-// Type: XnaToFna.ProxyDrawing.Point
-// Assembly: XnaToFna, Version=18.5.1.29483, Culture=neutral, PublicKeyToken=null
-// MVID: C1D3521D-C7E9-4C43-B430-D28CC69450A3
-// Assembly location: C:\Users\daniel\Desktop\Release\XnaToFna.exe
-
-using System;
+﻿using System;
 
 namespace XnaToFna.ProxyDrawing
 {

--- a/DuckGame/src/XnaToFna/ProxyMessageHelper.cs
+++ b/DuckGame/src/XnaToFna/ProxyMessageHelper.cs
@@ -1,10 +1,4 @@
-﻿// Decompiled with JetBrains decompiler
-// Type: XnaToFna.ProxyForms.ProxyMessageHelper
-// Assembly: XnaToFna, Version=18.5.1.29483, Culture=neutral, PublicKeyToken=null
-// MVID: C1D3521D-C7E9-4C43-B430-D28CC69450A3
-// Assembly location: C:\Users\daniel\Desktop\Release\XnaToFna.exe
-
-using System;
+﻿using System;
 using System.Security;
 using System.Security.Permissions;
 using System.Text;

--- a/DuckGame/src/XnaToFna/Rectangle.cs
+++ b/DuckGame/src/XnaToFna/Rectangle.cs
@@ -1,10 +1,4 @@
-﻿// Decompiled with JetBrains decompiler
-// Type: XnaToFna.ProxyDrawing.Rectangle
-// Assembly: XnaToFna, Version=18.5.1.29483, Culture=neutral, PublicKeyToken=null
-// MVID: C1D3521D-C7E9-4C43-B430-D28CC69450A3
-// Assembly location: C:\Users\daniel\Desktop\Release\XnaToFna.exe
-
-using System;
+﻿using System;
 
 namespace XnaToFna.ProxyDrawing
 {

--- a/DuckGame/src/XnaToFna/SoundEffectTransformer.cs
+++ b/DuckGame/src/XnaToFna/SoundEffectTransformer.cs
@@ -1,10 +1,4 @@
-﻿//// Decompiled with JetBrains decompiler
-//// Type: XnaToFna.ContentTransformers.SoundEffectTransformer
-//// Assembly: XnaToFna, Version=18.5.1.29483, Culture=neutral, PublicKeyToken=null
-//// MVID: C1D3521D-C7E9-4C43-B430-D28CC69450A3
-//// Assembly location: C:\Users\daniel\Desktop\Release\XnaToFna.exe
-
-//using Microsoft.Xna.Framework.Audio;
+﻿//using Microsoft.Xna.Framework.Audio;
 //using Microsoft.Xna.Framework.Content;
 //using System;
 //using System.Collections.Generic;

--- a/DuckGame/src/XnaToFna/StackOpHelper.cs
+++ b/DuckGame/src/XnaToFna/StackOpHelper.cs
@@ -1,10 +1,4 @@
-﻿// Decompiled with JetBrains decompiler
-// Type: XnaToFna.StackOpHelper
-// Assembly: XnaToFna, Version=18.5.1.29483, Culture=neutral, PublicKeyToken=null
-// MVID: C1D3521D-C7E9-4C43-B430-D28CC69450A3
-// Assembly location: C:\Users\daniel\Desktop\Release\XnaToFna.exe
-
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Reflection;
 

--- a/DuckGame/src/XnaToFna/StubXDKHelper.cs
+++ b/DuckGame/src/XnaToFna/StubXDKHelper.cs
@@ -1,10 +1,4 @@
-﻿// Decompiled with JetBrains decompiler
-// Type: XnaToFna.StubXDK.StubXDKHelper
-// Assembly: XnaToFna, Version=18.5.1.29483, Culture=neutral, PublicKeyToken=null
-// MVID: C1D3521D-C7E9-4C43-B430-D28CC69450A3
-// Assembly location: C:\Users\daniel\Desktop\Release\XnaToFna.exe
-
-using System;
+﻿using System;
 using System.Reflection;
 
 namespace XnaToFna.StubXDK

--- a/DuckGame/src/XnaToFna/SyncResult.cs
+++ b/DuckGame/src/XnaToFna/SyncResult.cs
@@ -1,10 +1,4 @@
-﻿// Decompiled with JetBrains decompiler
-// Type: XnaToFna.SyncResult
-// Assembly: XnaToFna, Version=18.5.1.29483, Culture=neutral, PublicKeyToken=null
-// MVID: C1D3521D-C7E9-4C43-B430-D28CC69450A3
-// Assembly location: C:\Users\daniel\Desktop\Release\XnaToFna.exe
-
-using System;
+﻿using System;
 using System.Threading;
 
 namespace XnaToFna

--- a/DuckGame/src/XnaToFna/TitleServiceConnection.cs
+++ b/DuckGame/src/XnaToFna/TitleServiceConnection.cs
@@ -1,10 +1,4 @@
-﻿// Decompiled with JetBrains decompiler
-// Type: XnaToFna.StubXDK.GamerServices.TitleServiceConnection
-// Assembly: XnaToFna, Version=18.5.1.29483, Culture=neutral, PublicKeyToken=null
-// MVID: C1D3521D-C7E9-4C43-B430-D28CC69450A3
-// Assembly location: C:\Users\daniel\Desktop\Release\XnaToFna.exe
-
-using System;
+﻿using System;
 using System.ComponentModel;
 using System.Net;
 

--- a/DuckGame/src/XnaToFna/TitleServiceConnectionStatus.cs
+++ b/DuckGame/src/XnaToFna/TitleServiceConnectionStatus.cs
@@ -1,10 +1,4 @@
-﻿// Decompiled with JetBrains decompiler
-// Type: XnaToFna.StubXDK.GamerServices.TitleServiceConnectionStatus
-// Assembly: XnaToFna, Version=18.5.1.29483, Culture=neutral, PublicKeyToken=null
-// MVID: C1D3521D-C7E9-4C43-B430-D28CC69450A3
-// Assembly location: C:\Users\daniel\Desktop\Release\XnaToFna.exe
-
-namespace XnaToFna.StubXDK.GamerServices
+﻿namespace XnaToFna.StubXDK.GamerServices
 {
     public enum TitleServiceConnectionStatus
     {

--- a/DuckGame/src/XnaToFna/TitleServiceDescription.cs
+++ b/DuckGame/src/XnaToFna/TitleServiceDescription.cs
@@ -1,10 +1,4 @@
-﻿// Decompiled with JetBrains decompiler
-// Type: XnaToFna.StubXDK.GamerServices.TitleServiceDescription
-// Assembly: XnaToFna, Version=18.5.1.29483, Culture=neutral, PublicKeyToken=null
-// MVID: C1D3521D-C7E9-4C43-B430-D28CC69450A3
-// Assembly location: C:\Users\daniel\Desktop\Release\XnaToFna.exe
-
-namespace XnaToFna.StubXDK.GamerServices
+﻿namespace XnaToFna.StubXDK.GamerServices
 {
     public class TitleServiceDescription
     {

--- a/DuckGame/src/XnaToFna/TitleServiceDirectory.cs
+++ b/DuckGame/src/XnaToFna/TitleServiceDirectory.cs
@@ -1,10 +1,4 @@
-﻿// Decompiled with JetBrains decompiler
-// Type: XnaToFna.StubXDK.GamerServices.TitleServiceDirectory
-// Assembly: XnaToFna, Version=18.5.1.29483, Culture=neutral, PublicKeyToken=null
-// MVID: C1D3521D-C7E9-4C43-B430-D28CC69450A3
-// Assembly location: C:\Users\daniel\Desktop\Release\XnaToFna.exe
-
-using System;
+﻿using System;
 
 namespace XnaToFna.StubXDK.GamerServices
 {

--- a/DuckGame/src/XnaToFna/WndProc.cs
+++ b/DuckGame/src/XnaToFna/WndProc.cs
@@ -1,10 +1,4 @@
-﻿// Decompiled with JetBrains decompiler
-// Type: XnaToFna.WndProc
-// Assembly: XnaToFna, Version=18.5.1.29483, Culture=neutral, PublicKeyToken=null
-// MVID: C1D3521D-C7E9-4C43-B430-D28CC69450A3
-// Assembly location: C:\Users\daniel\Desktop\Release\XnaToFna.exe
-
-using System;
+﻿using System;
 
 namespace XnaToFna
 {

--- a/DuckGame/src/XnaToFna/X360Helper.cs
+++ b/DuckGame/src/XnaToFna/X360Helper.cs
@@ -1,10 +1,4 @@
-﻿// Decompiled with JetBrains decompiler
-// Type: XnaToFna.X360Helper
-// Assembly: XnaToFna, Version=18.5.1.29483, Culture=neutral, PublicKeyToken=null
-// MVID: C1D3521D-C7E9-4C43-B430-D28CC69450A3
-// Assembly location: C:\Users\daniel\Desktop\Release\XnaToFna.exe
-
-using System.Threading;
+﻿using System.Threading;
 
 namespace XnaToFna
 {

--- a/DuckGame/src/XnaToFna/XEXImageData.cs
+++ b/DuckGame/src/XnaToFna/XEXImageData.cs
@@ -1,10 +1,4 @@
-﻿//// Decompiled with JetBrains decompiler
-//// Type: XnaToFna.XEX.XEXImageData
-//// Assembly: XnaToFna, Version=18.5.1.29483, Culture=neutral, PublicKeyToken=null
-//// MVID: C1D3521D-C7E9-4C43-B430-D28CC69450A3
-//// Assembly location: C:\Users\daniel\Desktop\Release\XnaToFna.exe
-
-//using System;
+﻿//using System;
 //using System.Collections.Generic;
 //using System.IO;
 //using System.Security.Cryptography;

--- a/DuckGame/src/XnaToFna/XNAtofnaProgram.cs
+++ b/DuckGame/src/XnaToFna/XNAtofnaProgram.cs
@@ -1,10 +1,4 @@
-﻿//// Decompiled with JetBrains decompiler
-//// Type: XnaToFna.Program
-//// Assembly: XnaToFna, Version=18.5.1.29483, Culture=neutral, PublicKeyToken=null
-//// MVID: C1D3521D-C7E9-4C43-B430-D28CC69450A3
-//// Assembly location: C:\Users\daniel\Desktop\Release\XnaToFna.exe
-
-//using Mono.Cecil;
+﻿//using Mono.Cecil;
 //using MonoMod;
 //using MonoMod.Utils;
 //using System;

--- a/DuckGame/src/XnaToFna/XnaToFnaExt.cs
+++ b/DuckGame/src/XnaToFna/XnaToFnaExt.cs
@@ -1,10 +1,4 @@
-﻿// Decompiled with JetBrains decompiler
-// Type: XnaToFna.XnaToFnaExt
-// Assembly: XnaToFna, Version=18.5.1.29483, Culture=neutral, PublicKeyToken=null
-// MVID: C1D3521D-C7E9-4C43-B430-D28CC69450A3
-// Assembly location: C:\Users\daniel\Desktop\Release\XnaToFna.exe
-
-using Mono.Cecil;
+﻿using Mono.Cecil;
 using Mono.Cecil.Cil;
 using System;
 using System.Diagnostics;

--- a/DuckGame/src/XnaToFna/XnaToFnaGame.cs
+++ b/DuckGame/src/XnaToFna/XnaToFnaGame.cs
@@ -1,10 +1,4 @@
-﻿// Decompiled with JetBrains decompiler
-// Type: XnaToFna.XnaToFnaGame
-// Assembly: XnaToFna, Version=18.5.1.29483, Culture=neutral, PublicKeyToken=null
-// MVID: C1D3521D-C7E9-4C43-B430-D28CC69450A3
-// Assembly location: C:\Users\daniel\Desktop\Release\XnaToFna.exe
-
-using Microsoft.Xna.Framework;
+﻿using Microsoft.Xna.Framework;
 using XnaToFna.ProxyForms;
 
 namespace XnaToFna

--- a/DuckGame/src/XnaToFna/XnaToFnaHelper.cs
+++ b/DuckGame/src/XnaToFna/XnaToFnaHelper.cs
@@ -1,10 +1,4 @@
-﻿// Decompiled with JetBrains decompiler
-// Type: XnaToFna.XnaToFnaHelper
-// Assembly: XnaToFna, Version=18.5.1.29483, Culture=neutral, PublicKeyToken=null
-// MVID: C1D3521D-C7E9-4C43-B430-D28CC69450A3
-// Assembly location: C:\Users\daniel\Desktop\Release\XnaToFna.exe
-
-using DuckGame;
+﻿using DuckGame;
 using Microsoft.Xna.Framework;
 using Microsoft.Xna.Framework.Input;
 using System;

--- a/DuckGame/src/XnaToFna/XnaToFnaMapping.cs
+++ b/DuckGame/src/XnaToFna/XnaToFnaMapping.cs
@@ -1,10 +1,4 @@
-﻿// Decompiled with JetBrains decompiler
-// Type: XnaToFna.XnaToFnaMapping
-// Assembly: XnaToFna, Version=18.5.1.29483, Culture=neutral, PublicKeyToken=null
-// MVID: C1D3521D-C7E9-4C43-B430-D28CC69450A3
-// Assembly location: C:\Users\daniel\Desktop\Release\XnaToFna.exe
-
-using Mono.Cecil;
+﻿using Mono.Cecil;
 
 namespace XnaToFna
 {

--- a/DuckGame/src/XnaToFna/XnaToFnaModder.cs
+++ b/DuckGame/src/XnaToFna/XnaToFnaModder.cs
@@ -1,10 +1,4 @@
-﻿// Decompiled with JetBrains decompiler
-// Type: XnaToFna.XnaToFnaModder
-// Assembly: XnaToFna, Version=18.5.1.29483, Culture=neutral, PublicKeyToken=null
-// MVID: C1D3521D-C7E9-4C43-B430-D28CC69450A3
-// Assembly location: C:\Users\daniel\Desktop\Release\XnaToFna.exe
-
-using DuckGame;
+﻿using DuckGame;
 using Mono.Cecil;
 using MonoMod;
 using MonoMod.Utils;

--- a/DuckGame/src/XnaToFna/XnaToFnaUtil.cs
+++ b/DuckGame/src/XnaToFna/XnaToFnaUtil.cs
@@ -1,10 +1,4 @@
-﻿// Decompiled with JetBrains decompiler
-// Type: XnaToFna.XnaToFnaUtil
-// Assembly: XnaToFna, Version=18.5.1.29483, Culture=neutral, PublicKeyToken=null
-// MVID: C1D3521D-C7E9-4C43-B430-D28CC69450A3
-// Assembly location: C:\Users\daniel\Desktop\Release\XnaToFna.exe
-
-using DuckGame;
+﻿using DuckGame;
 using Mono.Cecil;
 using Mono.Cecil.Cil;
 using Mono.Collections.Generic;

--- a/DuckGame/src/XnaToFna/__LeaderboardIdentity__.cs
+++ b/DuckGame/src/XnaToFna/__LeaderboardIdentity__.cs
@@ -1,10 +1,4 @@
-﻿// Decompiled with JetBrains decompiler
-// Type: XnaToFna.StubXDK.GamerServices.__LeaderboardIdentity__
-// Assembly: XnaToFna, Version=18.5.1.29483, Culture=neutral, PublicKeyToken=null
-// MVID: C1D3521D-C7E9-4C43-B430-D28CC69450A3
-// Assembly location: C:\Users\daniel\Desktop\Release\XnaToFna.exe
-
-using MonoMod;
+﻿using MonoMod;
 
 namespace XnaToFna.StubXDK.GamerServices
 {

--- a/DuckGame/src/XnaToFna/__LeaderboardReader__.cs
+++ b/DuckGame/src/XnaToFna/__LeaderboardReader__.cs
@@ -1,10 +1,4 @@
-﻿// Decompiled with JetBrains decompiler
-// Type: XnaToFna.StubXDK.GamerServices.__LeaderboardReader__
-// Assembly: XnaToFna, Version=18.5.1.29483, Culture=neutral, PublicKeyToken=null
-// MVID: C1D3521D-C7E9-4C43-B430-D28CC69450A3
-// Assembly location: C:\Users\daniel\Desktop\Release\XnaToFna.exe
-
-using MonoMod;
+﻿using MonoMod;
 using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;

--- a/DuckGame/src/XnaToFna/__LeaderboardWriter__.cs
+++ b/DuckGame/src/XnaToFna/__LeaderboardWriter__.cs
@@ -1,10 +1,4 @@
-﻿// Decompiled with JetBrains decompiler
-// Type: XnaToFna.StubXDK.GamerServices.__LeaderboardWriter__
-// Assembly: XnaToFna, Version=18.5.1.29483, Culture=neutral, PublicKeyToken=null
-// MVID: C1D3521D-C7E9-4C43-B430-D28CC69450A3
-// Assembly location: C:\Users\daniel\Desktop\Release\XnaToFna.exe
-
-using MonoMod;
+﻿using MonoMod;
 using System;
 using System.Reflection;
 

--- a/DuckGame/src/XnaToFna/__LocalNetworkGamer__.cs
+++ b/DuckGame/src/XnaToFna/__LocalNetworkGamer__.cs
@@ -1,10 +1,4 @@
-﻿// Decompiled with JetBrains decompiler
-// Type: XnaToFna.StubXDK.Net.__LocalNetworkGamer__
-// Assembly: XnaToFna, Version=18.5.1.29483, Culture=neutral, PublicKeyToken=null
-// MVID: C1D3521D-C7E9-4C43-B430-D28CC69450A3
-// Assembly location: C:\Users\daniel\Desktop\Release\XnaToFna.exe
-
-using MonoMod;
+﻿using MonoMod;
 
 namespace XnaToFna.StubXDK.Net
 {

--- a/DuckGame/src/XnaToFna/__NetworkMachine__.cs
+++ b/DuckGame/src/XnaToFna/__NetworkMachine__.cs
@@ -1,10 +1,4 @@
-﻿// Decompiled with JetBrains decompiler
-// Type: XnaToFna.StubXDK.Net.__NetworkMachine__
-// Assembly: XnaToFna, Version=18.5.1.29483, Culture=neutral, PublicKeyToken=null
-// MVID: C1D3521D-C7E9-4C43-B430-D28CC69450A3
-// Assembly location: C:\Users\daniel\Desktop\Release\XnaToFna.exe
-
-using MonoMod;
+﻿using MonoMod;
 
 namespace XnaToFna.StubXDK.Net
 {

--- a/DuckGame/src/XnaToFna/__NetworkSession__.cs
+++ b/DuckGame/src/XnaToFna/__NetworkSession__.cs
@@ -1,10 +1,4 @@
-﻿// Decompiled with JetBrains decompiler
-// Type: XnaToFna.StubXDK.Net.__NetworkSession__
-// Assembly: XnaToFna, Version=18.5.1.29483, Culture=neutral, PublicKeyToken=null
-// MVID: C1D3521D-C7E9-4C43-B430-D28CC69450A3
-// Assembly location: C:\Users\daniel\Desktop\Release\XnaToFna.exe
-
-using MonoMod;
+﻿using MonoMod;
 using System;
 using System.Reflection;
 

--- a/DuckGame/src/XnaToFna/__PropertyDictionary__.cs
+++ b/DuckGame/src/XnaToFna/__PropertyDictionary__.cs
@@ -1,10 +1,4 @@
-﻿// Decompiled with JetBrains decompiler
-// Type: XnaToFna.StubXDK.GamerServices.__PropertyDictionary__
-// Assembly: XnaToFna, Version=18.5.1.29483, Culture=neutral, PublicKeyToken=null
-// MVID: C1D3521D-C7E9-4C43-B430-D28CC69450A3
-// Assembly location: C:\Users\daniel\Desktop\Release\XnaToFna.exe
-
-using MonoMod;
+﻿using MonoMod;
 
 namespace XnaToFna.StubXDK.GamerServices
 {

--- a/DuckGame/src/XnaToFna/really.cs
+++ b/DuckGame/src/XnaToFna/really.cs
@@ -1,10 +1,4 @@
-﻿// Decompiled with JetBrains decompiler
-// Type: XnaToFna.really
-// Assembly: XnaToFna, Version=18.5.1.29483, Culture=neutral, PublicKeyToken=null
-// MVID: C1D3521D-C7E9-4C43-B430-D28CC69450A3
-// Assembly location: C:\Users\daniel\Desktop\Release\XnaToFna.exe
-
-using System.Reflection;
+﻿using System.Reflection;
 
 namespace XnaToFna
 {


### PR DESCRIPTION
Wire type entity will swap to the next in line with tab+control (Wire ->WireActivator->WireButton, etc)
Wire trapdoors will now have their trap doors move whenever it is moved in the editor
Some naming of variables in the unholy `Editor.cs`