### PR TITLE
Add: Controller Count Configuration Dev Menu Option

### DIFF
--- a/DuckGame/AddedContent/DGRSettings.cs
+++ b/DuckGame/AddedContent/DGRSettings.cs
@@ -455,5 +455,7 @@ namespace DuckGame
         }
 
         [Marker.AutoConfig] public static bool NoConsoleLineLimit = false;
+
+        [Marker.AutoConfig] public static int ControllerCount = 8;
     }
 }

--- a/DuckGame/src/MonoTime/Options.cs
+++ b/DuckGame/src/MonoTime/Options.cs
@@ -485,6 +485,11 @@ namespace DuckGame
                 dgrDescription = "Toggles 50p mode, will always reset to false after game restart"
             });
 
+            menu.Add(new UIMenuItemNumber("Controller Count", field: new FieldBinding(typeof(DGRSettings), nameof(DGRSettings.ControllerCount), 4, 300, 1), step: 1)
+            {
+                dgrDescription = "Maximum number of controllers supported (requires restart)"
+            });
+
             menu.Add(new UIText(" ", Color.White));
             menu.Add(new UIMenuItem("BACK", new UIMenuActionOpenMenu(menu, pPrev), backButton: true));
             return menu;

--- a/DuckGame/src/Program.cs
+++ b/DuckGame/src/Program.cs
@@ -309,7 +309,6 @@ namespace DuckGame
             DuckFile.Initialize();
             MarkerAttribute.Initialize(gameAssembly);
             AutoConfigHandler.Initialize();
-            int Controllers = 8;
             bool flag = false;
             for (int index = 0; index < args.Length; ++index)
             {
@@ -348,7 +347,7 @@ namespace DuckGame
                         {
                             try
                             {
-                                Controllers = Convert.ToInt32(args[index]);
+                                DGRSettings.ControllerCount = Convert.ToInt32(args[index]);
                             }
                             catch
                             { }
@@ -720,9 +719,9 @@ namespace DuckGame
         label_109:
             DeviceChangeNotifier.Start();
             DevConsole.Log("Starting Duck Game (" + DG.platform + ")...");
-            if (Controllers > 4)
+            if (DGRSettings.ControllerCount > 4)
             {
-                string controllerstring = Controllers.ToString();
+                string controllerstring = DGRSettings.ControllerCount.ToString();
                 DevConsole.Log("Setting Max Controller Count " + controllerstring);
                 Environment.SetEnvironmentVariable("FNA_GAMEPAD_NUM_GAMEPADS", controllerstring);
             }


### PR DESCRIPTION
I have been testing out the 50 player mode. It works great but I'm limited on the number of controllers available. 

This adds a developer menu item, next to the 50 player mode, that introduces a new configuration setting for the maximum number of controllers supported, defaulting to 8.

This will enable you to increase the count of the controllers to match the player count.

<img width="1282" height="752" alt="image" src="https://github.com/user-attachments/assets/7ffbd9fc-15a9-42ff-9678-d7008c3c9a30" />
