### PR TITLE
Fix Recorderation ArgumentOutOfRangeException

### DIFF
--- a/DuckGame/Recorderator/RecorderationSelector/RecorderationSelector.cs
+++ b/DuckGame/Recorderator/RecorderationSelector/RecorderationSelector.cs
@@ -24,10 +24,9 @@ namespace DuckGame
 
                 if (value != _selectedItemIndex)
                 {
-                    if (_selectedItemIndex < MenuItems.Count) 
-                    { 
-                        MenuItems[_selectedItemIndex].OnUnhover(); 
-                    }
+                    if (_selectedItemIndex < MenuItems.Count)
+                        MenuItems[_selectedItemIndex].OnUnhover();
+
                     MenuItems[value].OnHover();
                 }
                 


### PR DESCRIPTION
I'm bad at the game, so I find my replays to be far less interesting than I expect when I go back to look at them.  Deleting all of my replays was causing a crash.

Steps to reproduce:

1. Delete all of the clips in your clips folder starting at the bottom of the list.

In some scenarios toggling the folder was necessary to cause the crash after all of the clips were deleted (I was testing different scenarios with different folders and whatnot).

```
Crash Source: 
Mods apparently were not responsible for this crash.

System.ArgumentOutOfRangeException: Index was out of range. Must be non-negative and less than the size of the collection.
Parameter name: index
  at System.ThrowHelper.ThrowArgumentOutOfRangeException(System.ExceptionArgument, System.ExceptionResource) [46]  L:0
  at DuckGame.RecorderationSelector.Update() [0] /home/runner/work/DuckGameRebuilt/DuckGameRebuilt/DuckGame/Recorderator/RecorderationSelector/RecorderationSelector.cs L:125
  at DuckGame.Level.DoUpdate() [315] /home/runner/work/DuckGameRebuilt/DuckGameRebuilt/DuckGame/src/MonoTime/Level.cs L:721
  at DuckGame.Level.UpdateCurrentLevel() [28] /home/runner/work/DuckGameRebuilt/DuckGameRebuilt/DuckGame/src/MonoTime/Level.cs L:157
  at DuckGame.MonoMain.RunUpdate(Microsoft.Xna.Framework.GameTime) [1204] /home/runner/work/DuckGameRebuilt/DuckGameRebuilt/DuckGame/src/MonoTime/MonoMain.cs L:1499
  at DuckGame.MonoMain.Update(Microsoft.Xna.Framework.GameTime) [355] /home/runner/work/DuckGameRebuilt/DuckGameRebuilt/DuckGame/src/MonoTime/MonoMain.cs L:1225

Last 8 Lines of Console Output:
Level Switch (null -> TitleScreen)
Initializing level (255)
DGR Connected to discord
Added Controller 1: (8BitDo Ultimate 2 Wireless Controller for PC), GUID: c82d0b31, Mapping: 03000166c82d00000b31000000007200,*,a:b0,b:b1,x:b2,y:b3,back:b6,guide:b10,start:b7,leftstick:b8,rightstick:b9,leftshoulder:b4,rightshoulder:b5,dpup:h0.1,dpdown:h0.4,dpleft:h0.8,dpright:h0.2,leftx:a0,lefty:a1,rightx:a2,righty:a3,lefttrigger:a4,righttrigger:a5,crc:6601,platform:Windows
Level Switch (TitleScreen -> RecorderationSelector)
Initializing level (255)
ACFG Attempting save
ACFG Save success

Date: 01/14/2026 04:31:27
Version: 1.1.7717.16376
Platform: Windows 10 (Steam Build 8782838)(SFX)
Online: 0
Mods: nomods
Time Played: 00:00:35 (1857)
Special Code: 11 
Resolution: (A)3440x1440 (G)3440x1440 (Fullscreen(W))(RF 1740)
Level: DuckGame.RecorderationSelector
Command Line: -from "P:\Steam\steamapps\common\Duck Game\DuckGame.exe"
```

I force `SelectedItemIndex` to reclamp itself after any calls to `UpdateMenuItemList`.  I then found that the setter still tries to use the out-of-bounds value to call `.OnUnhover()` so I added a quick boundary check there.