### PR TITLE
Remove WindowsForms references (part 2).

### DIFF
--- a/DuckGame/AddedContent/Biverom/TreeSawing/FallingTree.cs
+++ b/DuckGame/AddedContent/Biverom/TreeSawing/FallingTree.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Windows.Automation.Peers;
 
 namespace DuckGame
 {

--- a/DuckGame/AddedContent/Biverom/TreeSawing/TreeEnd.cs
+++ b/DuckGame/AddedContent/Biverom/TreeSawing/TreeEnd.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Windows.Automation.Peers;
 
 namespace DuckGame
 {

--- a/DuckGame/DuckGame.csproj
+++ b/DuckGame/DuckGame.csproj
@@ -776,6 +776,7 @@
     <Compile Include="src\MonoTime\LUI\LUIText.cs" />
     <Compile Include="src\MonoTime\Materials\FullscreenMaterial.cs" />
     <Compile Include="src\MonoTime\Materials\MaterialFunBeam.cs" />
+    <Compile Include="src\MonoTime\File\RtfWriter.cs" />
     <Compile Include="src\MonoTime\UI\UIDGRDescribe.cs" />
     <Compile Include="src\MonoTime\UI\UISideButton.cs" />
     <Compile Include="src\WindowsPlatformStartup.cs" />

--- a/DuckGame/DuckGame.csproj
+++ b/DuckGame/DuckGame.csproj
@@ -2417,6 +2417,7 @@
     <Compile Include="src\XnaToFna\TitleServiceDescription.cs" />
     <Compile Include="src\XnaToFna\TitleServiceDirectory.cs" />
     <Compile Include="src\XnaToFna\TranspilerMapEntry.cs" />
+    <Compile Include="src\XnaToFna\GameFormForWinForms.cs" />
     <Compile Include="src\XnaToFna\WndProc.cs" />
     <Compile Include="src\XnaToFna\X360Helper.cs" />
     <Compile Include="src\XnaToFna\XnaToFnaExt.cs" />

--- a/DuckGame/src/DuckGame/AutoBlock.cs
+++ b/DuckGame/src/DuckGame/AutoBlock.cs
@@ -1,7 +1,5 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Windows.Documents;
-using static DuckGame.GoalType;
 
 namespace DuckGame
 {

--- a/DuckGame/src/DuckGame/Levels/TeamSelect2/ProfileSelector.cs
+++ b/DuckGame/src/DuckGame/Levels/TeamSelect2/ProfileSelector.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Windows.Documents;
 
 namespace DuckGame
 {

--- a/DuckGame/src/DuckGame/Levels/XMLLevel.cs
+++ b/DuckGame/src/DuckGame/Levels/XMLLevel.cs
@@ -5,8 +5,6 @@ using System.Collections.Generic;
 using System.IO;
 using System.IO.Compression;
 using static DuckGame.CMD;
-using System.Windows.Controls;
-using System.Windows.Documents;
 
 namespace DuckGame
 {

--- a/DuckGame/src/MonoTime/Console/DevConsole.cs
+++ b/DuckGame/src/MonoTime/Console/DevConsole.cs
@@ -1,6 +1,8 @@
 ﻿using AddedContent.Firebreak;
 using AddedContent.Firebreak.DuckShell.Implementation;
 using DuckGame.ConsoleEngine;
+using Microsoft.Xna.Framework;
+using SDL2;
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
@@ -9,14 +11,10 @@ using System.IO;
 using System.IO.Compression;
 using System.Linq;
 using System.Net;
-using System.Text;
-using System.Threading;
-using System.Windows.Forms;
-using SDL2;
-using System.Reflection;
 using System.Runtime.CompilerServices;
+using System.Text;
 using System.Text.RegularExpressions;
-using Microsoft.Xna.Framework;
+using System.Threading;
 
 namespace DuckGame
 {
@@ -1087,26 +1085,29 @@ namespace DuckGame
             }
         }
 
+        public static string GetNetLogFileName(string username)
+        {
+            return $"{DateTime.Now.ToShortDateString().Replace('/', '_')}_{DateTime.Now.ToLongTimeString().Replace(':', '_')}_{username}_netlog.rtf";
+        }
+
         public static void SaveNetLog(string pName = null)
         {
             FlushPendingLines();
-            string text = "";
+            string netLog = "";
+            var logFileName = pName;
             for (int index = Math.Max(core.lines.Count - 1500, 0);
                  index < core.lines.Count;
                  ++index)
-                text += core.lines.ElementAt(index).ToSendString();
-            if (pName == null)
-                pName =
-                    $"{DateTime.Now.ToShortDateString().Replace('/', '_')}_{DateTime.Now.ToLongTimeString().Replace(':', '_')}_{Steam.user.name}_netlog.rtf";
-            else if (!pName.EndsWith(".rtf"))
-                pName += ".rtf";
-            string str = DuckFile.FixInvalidPath(DuckFile.logDirectory + pName);
-            if (File.Exists(str))
-                File.Delete(str);
-            RichTextBox richTextBox = new FancyBitmapFont().MakeRTF(text);
-            DuckFile.CreatePath(str);
-            string path = str;
-            richTextBox.SaveFile(path);
+                netLog += core.lines.ElementAt(index).ToSendString();
+            if (logFileName == null)
+                logFileName = GetNetLogFileName(Steam.user.name);
+            else if (!logFileName.EndsWith(".rtf"))
+                logFileName += ".rtf";
+            string logFilePath = DuckFile.FixInvalidPath(DuckFile.logDirectory + logFileName);
+            if (File.Exists(logFilePath))
+                File.Delete(logFilePath);
+
+            RtfWriter.SaveLog(logFilePath, netLog);
         }
 
         public static void LogTransferComplete(NetworkConnection pConnection)
@@ -1114,12 +1115,9 @@ namespace DuckGame
             string receivedLogData = core.GetReceivedLogData(pConnection);
             if (receivedLogData != null)
             {
-                string pathString = DuckFile.FixInvalidPath(
-                    $"{DuckFile.logDirectory}{DateTime.Now.ToShortDateString().Replace('/', '_')}_{DateTime.Now.ToLongTimeString().Replace(':', '_')}_{pConnection.name}_netlog.rtf");
-                RichTextBox richTextBox = new FancyBitmapFont().MakeRTF(receivedLogData);
-                DuckFile.CreatePath(pathString);
-                string path = pathString;
-                richTextBox.SaveFile(path);
+                string logFileName = GetNetLogFileName(pConnection.name);
+                string logFilePath = DuckFile.FixInvalidPath($"{DuckFile.logDirectory}{logFileName}");
+                RtfWriter.SaveLog(logFilePath, receivedLogData);
             }
 
             core.requestingLogs.Remove(pConnection);

--- a/DuckGame/src/MonoTime/File/RtfWriter.cs
+++ b/DuckGame/src/MonoTime/File/RtfWriter.cs
@@ -1,0 +1,249 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.IO;
+
+namespace DuckGame
+{
+    /// <summary>
+    /// Replacement for "System.Windows.Forms.RichTextBox"'s SelectionColor() + SaveFile() functionality.
+    /// With support for DGR color syntax, example: "|RED|red text |PREV| normal text".
+    /// Created to remove the WinForms references with a functional equivalent.
+    /// </summary>
+    public class RtfWriter
+    {
+        public static class Tag
+        {
+            public const string ColorFont = @"\cf";
+            public const string Unicode = @"\u";
+            public const string NewLine = @"\par ";
+
+            public const string Header = @"{\rtf1\ansi";
+            public const string HeaderColorTable = @"{\colortbl ;";
+            public const string HeaderFontTable = @"{\fonttbl ;";
+
+            // These optional headers are used by WinForm's RichTextBox to define additional options like language and font:
+            public const string HeaderLang = @"\ansicpg1252\deff0\nouicompat\deflang1033";
+            public const string HeaderFonts = @"{\fonttbl{\f0\fnil\fcharset0 Microsoft Sans Serif; } }";
+            public const string HeaderMsFontSize = @"{\*\generator Riched20 10.0.26100}\viewkind4\uc1\pard\cf1\f0\fs17";
+
+            // HEADERS INFO:
+            // \rtf1            RTF version 1.x
+            // \ansi            Select ANSI charsed, used along with \ansicpgXXXX. UTF-8 encoding is not supported in RTF.
+            // \ansicpg1252     Windows Code Page 1252  (Western European (Latin-1 Windows)). Tis is the recommended international value. https://learn.microsoft.com/en-us/windows/win32/intl/code-page-identifiers
+            // \deff0           Sets default font to f0
+            // \nouicompat      Sets "no UI compatibility mode" to remove legacy behavior.
+            // \deflang1033     Sets the default language using an LCID (Language Code Identifier), used for spell check and hyphenation. 1033 = English (US). https://help.tradestation.com/10_00/eng/tsdevhelp/elobject/class_el/lcid_values.htm
+            // \fnil            "font nil" selects the default system font as a fallback font.
+            // \fcharset0       Sets the char-set for the font to 0 = ANSI.
+            // {\*\generator Riched20 10.0.26100}       Name of the software that generated the RTF, this is the Windows RichEdit tag.
+            // \viewkind4       Sets the viewer to use for display. 0 = normal. 1 = outline. 4 = print layout.
+            // \uc1             Sets the unicode fallback length to 1 char.
+            // \pard            Resets paragraph formatting: indent, alignment and spacing.
+            // \fs17            Sets font-size to 17 half-points.
+        }
+
+        public static void AppendColorFontTag(StringBuilder rtf, int colorIndex)
+        {
+            rtf.Append(Tag.ColorFont);
+            rtf.Append(colorIndex);
+            rtf.Append(' ');
+        }
+
+        public static void AppendColorFontTag(StringBuilder rtf, List<Color> colorList, Color color)
+        {
+            if (!colorList.Contains(color)) {
+                colorList.Add(color);
+            }
+            int colorIndex = colorList.IndexOf(color) + 1;
+            AppendColorFontTag(rtf, colorIndex);
+        }
+
+        public static bool IsUnicodeChar(char c) => c > 127;
+
+        private static void AppendAsUnicodeEscapedChar(StringBuilder rtf, char c)
+            => rtf.Append(Tag.Unicode).Append((short)c).Append('?');
+
+        public static void AppendEscapingUnicodeChars(StringBuilder rtf, char c)
+        {
+            if (IsUnicodeChar(c)) {
+                AppendAsUnicodeEscapedChar(rtf, c);
+            }
+            else {
+                rtf.Append(c);
+            }
+        }
+
+        public const string SpecialCharacters = @"{}\";
+        public static bool IsSpecialChar(char c)
+            => SpecialCharacters.Contains(c);
+
+        private static void AppendAsEscapedSpecialChar(StringBuilder rtf, char c)
+            => rtf.Append('\\').Append(c);
+
+        public static string EscapeSpecialChar(char c)
+            => IsSpecialChar(c) ? $"\\{c}" : c.ToString();
+
+        public static void AppendEscapingUnicodeAndSpecialChars(StringBuilder rtf, char c)
+        {
+            if (IsSpecialChar(c)) {
+                AppendAsEscapedSpecialChar(rtf, c);
+            }
+            else {
+                AppendEscapingUnicodeChars(rtf, c);
+            }
+        }
+
+        public static void AppendEscapingUnicodeAndSpecialChars(StringBuilder rtf, string text)
+        {
+            foreach (char c in text ?? "") {
+                AppendEscapingUnicodeAndSpecialChars(rtf, c);
+            }
+        }
+
+        public static string EscapeText(string text)
+        {
+            var rtf = new StringBuilder();
+            AppendEscapingUnicodeAndSpecialChars(rtf, text);
+            return rtf.ToString();
+        }
+
+        public static string CreateRtfDoc(List<Color> colors, StringBuilder body)
+        {
+            var rtf = new StringBuilder(body.Length + 228);
+            AppendSection(rtf, colors, body);
+            rtf.Append('\0'); // This is optional. Added to mimic the same behavior as the previous RichTextBox method.
+            return rtf.ToString();
+        }
+
+        public static void AppendSection(StringBuilder rtf, List<Color> colors, StringBuilder body)
+        {
+            rtf.AppendLine(Tag.Header);
+            rtf.AppendLine(Tag.HeaderLang);
+            rtf.AppendLine(Tag.HeaderFonts);
+            rtf.AppendLine(Tag.HeaderMsFontSize);
+            rtf.AppendLine(Tag.HeaderColorTable);
+            foreach (var c in colors)
+            {
+                AppendHeaderColor(rtf, c);
+            }
+            rtf.AppendLine("}");
+            rtf.Append(body);
+            rtf.AppendLine("\n}");
+        }
+
+        public static void AppendHeaderColor(StringBuilder rtf, Color c)
+            => AppendHeaderColor(rtf, c.r, c.g, c.b);
+
+        public static void AppendHeaderColor(StringBuilder rtf, byte red, byte green, byte blue)
+        {
+            rtf.Append(@"\red");
+            rtf.Append(red);
+            rtf.Append(@"\green");
+            rtf.Append(green);
+            rtf.Append(@"\blue");
+            rtf.Append(blue);
+            rtf.AppendLine(";");
+        }
+
+        public static string CreateRtfFromDgLogs(string text)
+        {
+            var parsedLog = ParseDgLogs(text);
+            return CreateRtfDoc(parsedLog.Colors, parsedLog.Body);
+        }
+
+        public static (List<Color> Colors, StringBuilder Body) ParseDgLogs(string text)
+        {
+            var colors = new List<Color> { Color.Black };
+            var body = new StringBuilder((text?.Length ?? 0) * 2);
+            if (string.IsNullOrEmpty(text)) {
+                return (colors, body);
+            }
+            var currentColor = Color.Black;
+            var previousColor = Color.Black;
+
+            for (int letterIndex = 0; letterIndex < text.Length; letterIndex++)
+            {
+                char c = text[letterIndex];
+
+                if (c == '|')
+                {
+                    var tag = ParseDgPipeTag(text, ref letterIndex);
+                    Color parsedColor = ParseDgColorName(tag.Text, previousColor);
+                    bool isValidColor = parsedColor != Color.Transparent;
+
+                    if (isValidColor)
+                    {
+                        previousColor = currentColor;
+                        currentColor = parsedColor;
+                        if (currentColor == Color.White) {
+                            currentColor = Color.Black;
+                        }
+                        if (currentColor != previousColor) {
+                            AppendColorFontTag(body, colors, currentColor);
+                        }
+                    }
+                    else {
+                        body.Append(c);
+                        AppendEscapingUnicodeAndSpecialChars(body, tag.Text);
+                        if (tag.ClosingChar.HasValue) {
+                            AppendEscapingUnicodeAndSpecialChars(body, tag.ClosingChar.Value);
+                        }
+                    }
+                }
+                else if (c == '\n' || c == '\r') {
+                    previousColor = Color.Black;
+                    if (currentColor != Color.Black) {
+                        AppendColorFontTag(body, colors, Color.Black);
+                        currentColor = Color.Black;
+                    }
+                    body.AppendLine(Tag.NewLine);
+                }
+                else {
+                    AppendEscapingUnicodeAndSpecialChars(body, c);
+                }
+            }
+            return (colors, body);
+        }
+
+        public static Color ParseDgColorName(string colorText, Color previousColor)
+        {
+            if (colorText == "PREV") {
+                return previousColor;
+            }
+            else {
+                return Colors.ParseColor(colorText);
+            }
+        }
+
+        public static (string Text, char? ClosingChar) ParseDgPipeTag(string text, ref int parseIndex)
+        {
+            var tag = new StringBuilder(12);
+            char? closingChar = null;
+            while (true)
+            {
+                ++parseIndex;
+                bool isEndOfText = parseIndex >= (text?.Length ?? 0);
+                if (isEndOfText) {
+                    break;
+                }
+                char c = text[parseIndex];
+                bool isEndOfTag = c == ' ' || c == '|';
+                if (isEndOfTag) {
+                    closingChar = c;
+                    break;
+                }
+                tag.Append(c);
+            };
+            return (tag.ToString(), closingChar);
+        }
+
+        public static void SaveLog(string logFilePath, string netLog)
+        {
+            DuckFile.CreatePath(logFilePath);
+            var rtfText = CreateRtfFromDgLogs(netLog);
+            File.WriteAllText(logFilePath, rtfText, Encoding.ASCII);
+        }
+    }
+}

--- a/DuckGame/src/MonoTime/Input/Input.cs
+++ b/DuckGame/src/MonoTime/Input/Input.cs
@@ -5,7 +5,6 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
-using System.Windows.Documents;
 
 namespace DuckGame
 {

--- a/DuckGame/src/MonoTime/LevelEditor/Editor.cs
+++ b/DuckGame/src/MonoTime/LevelEditor/Editor.cs
@@ -9,7 +9,7 @@ using System.Threading;
 using Microsoft.Xna.Framework;
 using Microsoft.Xna.Framework.Graphics;
 using SDL2;
-//using System.Windows.Forms;
+
 namespace DuckGame
 {
     public class Editor : Level

--- a/DuckGame/src/MonoTime/MonoMain.cs
+++ b/DuckGame/src/MonoTime/MonoMain.cs
@@ -16,7 +16,6 @@ using System.Security;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
-using System.Windows.Forms;
 using AddedContent.Hyeve;
 using XnaToFna;
 
@@ -174,7 +173,7 @@ namespace DuckGame
         public int times;
         public static long framesBackInFocus = 0;
         public static bool showingSaveTool = false;
-        public static Form saveTool;
+        public static object saveTool;
         //private bool _checkedSave;
         //private bool _corruptSave;
         //private bool _didStartInit;
@@ -1174,9 +1173,13 @@ namespace DuckGame
 
             if (showingSaveTool && saveTool == null && File.Exists("SaveTool.dll"))
             {
-                saveTool = Activator.CreateInstance(Assembly.Load(File.ReadAllBytes(Directory.GetCurrentDirectory() + "/SaveTool.dll")).GetType("SaveRecovery.SaveTool")) as Form;
+                saveTool = Activator.CreateInstance(Assembly.Load(File.ReadAllBytes(Directory.GetCurrentDirectory() + "/SaveTool.dll")).GetType("SaveRecovery.SaveTool"));
                 Graphics.mouseVisible = true;
-                int num = (int)saveTool.ShowDialog();
+                var saveToolType = saveTool.GetType();
+                var showDialogMethod = saveToolType.GetMethod("ShowDialog", Type.EmptyTypes);
+                if (showDialogMethod != null) {
+                    int result = (int)showDialogMethod.Invoke(saveTool, null);
+                }
                 Program.crashed = true;
                 Program.main.KillEverything();
                 Program.main.Exit();

--- a/DuckGame/src/MonoTime/MonoMain.cs
+++ b/DuckGame/src/MonoTime/MonoMain.cs
@@ -775,10 +775,7 @@ namespace DuckGame
 
         protected override void OnExiting(object sender, EventArgs args)
         {
-            if (XnaToFnaHelper.fillinform != null)
-            {
-                XnaToFnaHelper.fillinform.Close();
-            }
+            base.OnExiting(sender, args);
             InvokeOnGameExitEvent(false);
             KillEverything();
             Process.GetCurrentProcess().Kill();

--- a/DuckGame/src/MonoTime/Options.cs
+++ b/DuckGame/src/MonoTime/Options.cs
@@ -2,7 +2,6 @@
 using System.Collections.Generic;
 using System.Linq;
 using System;
-using System.Windows.Media.Animation;
 
 namespace DuckGame
 {

--- a/DuckGame/src/MonoTime/Render/FancyBitmapFont.cs
+++ b/DuckGame/src/MonoTime/Render/FancyBitmapFont.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Windows.Forms;
 
 namespace DuckGame
 {
@@ -1253,47 +1252,6 @@ namespace DuckGame
                     }
                 }
             }
-        }
-        public RichTextBox MakeRTF(string text)
-        {
-            RichTextBox richTextBox = new RichTextBox();
-            Color color2 = Color.Black;
-            string text1 = "";
-            richTextBox.SelectionColor = System.Drawing.Color.Black;
-            for (_letterIndex = 0; _letterIndex < text.Length; ++_letterIndex)
-            {
-                bool flag = false;
-                if (text[_letterIndex] == '|')
-                {
-                    int letterIndex = _letterIndex;
-                    if (color2 != Colors.Transparent)
-                    {
-                        _previousColor = color2;
-                    }
-                    color2 = ParseColor(text);
-                    if (color2 != Colors.Transparent)
-                    {
-                        if (color2 == Color.White)
-                            color2 = Color.Black;
-                        richTextBox.AppendText(text1);
-                        text1 = "";
-                        richTextBox.SelectionColor = System.Drawing.Color.FromArgb(color2.r, color2.g, color2.b);
-                        flag = true;
-                    }
-                    else
-                        _letterIndex = letterIndex;
-                }
-                if (text[_letterIndex] == '\n')
-                {
-                    richTextBox.AppendText(text1);
-                    text1 = "";
-                    richTextBox.SelectionColor = System.Drawing.Color.Black;
-                }
-                if (!flag)
-                    text1 += text[_letterIndex].ToString();
-            }
-            richTextBox.AppendText(text1);
-            return richTextBox;
         }
     }
 }

--- a/DuckGame/src/Program.cs
+++ b/DuckGame/src/Program.cs
@@ -12,7 +12,6 @@ using System.Resources;
 using System.Reflection;
 using System.Diagnostics;
 using System.Collections;
-using System.Windows.Forms;
 using System.Globalization;
 using System.IO.Compression;
 using AddedContent.Firebreak;
@@ -160,7 +159,7 @@ namespace DuckGame
             }
             else
                 AppDomain.CurrentDomain.AssemblyLoad += new AssemblyLoadEventHandler(WindowsPlatformStartup.AssemblyLoad);
-            Application.ThreadException += new ThreadExceptionEventHandler(UnhandledThreadExceptionTrapper);
+
             AppDomain.CurrentDomain.UnhandledException += new UnhandledExceptionEventHandler(WindowsPlatformStartup.UnhandledExceptionTrapper);
             AppDomain.CurrentDomain.AssemblyResolve += new ResolveEventHandler(Resolve);
             TaskScheduler.UnobservedTaskException += UnhandledExceptionUnobserved;
@@ -662,7 +661,7 @@ namespace DuckGame
                     default:
                         if (args[index] == "-nolaunch")
                         {
-                            int num = (int)MessageBox.Show("-nolaunch Command Line Option activated! Cancelling launch!");
+                            Console.WriteLine("-nolaunch Command Line Option activated! Cancelling launch!");
                             return;
                         }
                         if (args[index] == "-alternateSaveLocation")

--- a/DuckGame/src/XnaToFna/Control.cs
+++ b/DuckGame/src/XnaToFna/Control.cs
@@ -52,8 +52,6 @@ namespace XnaToFna.ProxyForms
 
         public static Control FromHandle(IntPtr ptr)
         {
-            if (XnaToFnaHelper.fillinform != null)
-                return XnaToFnaHelper.fillinform;
             int index = (int)ptr - 1;
             if (index < 0 || AllControls.Count <= index)
                 return null;

--- a/DuckGame/src/XnaToFna/GameForm.cs
+++ b/DuckGame/src/XnaToFna/GameForm.cs
@@ -8,6 +8,18 @@ namespace XnaToFna.ProxyForms
     public sealed class GameForm : Form
     {
         public static GameForm Instance;
+
+        public static GameForm GetInstance(Game game)
+        {
+            if (Instance == null)
+            {
+                XnaToFnaHelper.Log("[ProxyForms] Creating game ProxyForms.GameForm");
+                Instance = new GameForm();
+                Instance.HookFormToGameExit(game);
+            }
+            return Instance;
+        }
+
         private bool _Dirty;
         private bool FakeFullscreenWindow;
         private Rectangle _WindowedBounds;
@@ -15,6 +27,30 @@ namespace XnaToFna.ProxyForms
         private FormBorderStyle _FormBorderStyle = FormBorderStyle.FixedDialog;
         private FormWindowState _WindowState;
         private FormStartPosition _StartPosition = FormStartPosition.WindowsDefaultLocation;
+        private bool _isExiting = false;
+
+        public void HookFormToGameExit(Game game)
+        {
+            if (game == null) {
+                return;
+            }
+            game.Exiting += (s, e) => {
+                if (!_isExiting)
+                {
+                    _isExiting= true;
+                    Instance?.Close();
+                }
+            };
+        }
+
+        protected override void _Close()
+        {
+            if (!_isExiting)
+            {
+                _isExiting = true;
+                XnaToFnaHelper.Game?.Exit();
+            }
+        }
 
         private bool Dirty
         {
@@ -156,8 +192,6 @@ namespace XnaToFna.ProxyForms
         {
             SDLWindowSizeChanged(null, null);
         }
-
-        protected override void _Close() => XnaToFnaHelper.Game.Exit();
 
         public void ApplyChanges()
         {

--- a/DuckGame/src/XnaToFna/GameFormForWinForms.cs
+++ b/DuckGame/src/XnaToFna/GameFormForWinForms.cs
@@ -1,0 +1,165 @@
+﻿using System;
+using System.Linq;
+using System.Reflection;
+using Microsoft.Xna.Framework;
+
+namespace XnaToFna.ProxyForms
+{
+    /// <summary>
+    /// This is an FNA compatibility shim for XNA mods that 
+    /// were using references to XNA's "Game.Window.Handle" casted as a WinForm's Form.
+    /// It is a non intrusive alternative to "ProxyForms.GameForm" 
+    /// that doesn't require relinking multiple WinForms types.
+    /// 
+    /// What this shim does:
+    /// - Keeps transparent compatibility with XNA mods on FNA (on Windows).
+    /// - Supports non-Windows OS by using a fallback to return null/Zero.
+    /// - Creates a valid Form handle using reflection to prevent hard references to WinForms.
+    /// - Only requires re-linking "Game.Window.Handle" function, not the whole "Form" class and methods.
+    /// 
+    /// Why some mods need this:
+    /// In XNA the "Game.Window.Handle" property was a pointer to the main "System.Windows.Forms.Form".
+    /// In FNA "Game.Window.Handle" still exists, but it is an SDL handle, no longer a Form.
+    /// The SDL handle can be of different types: HWND (on Windows) / X11 (on Linux) / Cocoa (on MacOS).
+    /// The SDL handle cannot be converted into a WinForm's Form anymore, not even on Windows.
+    /// 
+    /// How to solve it:
+    /// Re-linking the mod's DLL references to "Game.Window.Handle" 
+    /// and replacing it with "GameFormForWinForms.GetHandle()".
+    /// This will return a valid WinForm's Form handle on Windows, and null/Zero in Linux.
+    /// 
+    /// Example of mod's code having this problem (deprecated pattern):
+    /// var form = ((System.Windows.Forms.Form) System.Windows.Forms.Control.FromHandle(DuckGame.MonoMain.instance.Window.Handle));
+    /// form.FormClosing += SomeModFunction;
+    /// 
+    /// For new mods please use a Harmony prefix patch in 
+    /// "MonoMain.OnExiting" for a cross-platform solution instead.
+    /// </summary>
+    internal static class GameFormForWinForms
+    {
+        /// <summary>
+        /// This object type is "System.Windows.Forms.Form".
+        /// It is created using reflection to avoid direct references to WinForms.
+        /// </summary>
+        public static object FormInstance;
+        private static IntPtr _handle = IntPtr.Zero;
+        private static bool _initialized;
+
+        public const string WinFormsAssemblyName = "System.Windows.Forms";
+        public const string WinFormsAssemblyStrongName = WinFormsAssemblyName + ", Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089";
+        public const string WinFormsNamespace = "System.Windows.Forms";
+
+        public static class FormClass
+        {
+            public const string Name = "Form";
+            public const string NameWithNamespace = WinFormsNamespace + "." + Name;
+
+            public static class Methods
+            {
+                public const string Close = "Close";
+                public const string Show = "Show";
+            }
+            public static class Properties
+            {
+                public const string Handle = "Handle";
+                public const string ShowInTaskbar = "ShowInTaskbar";
+                public const string FormBorderStyle = "FormBorderStyle";
+                public const string Opacity = "Opacity";
+            }
+        }
+
+        public static object GetInstance(Game game)
+        {
+            if (!_initialized) {
+                CreateFormAndHandle(game);
+            }
+            return FormInstance;
+        }
+
+        public static IntPtr GetHandle(Game game)
+        {
+            if (!_initialized) {
+                CreateFormAndHandle(game);
+            }
+            return _handle;
+        }
+
+        private static void CreateFormAndHandle(Game game)
+        {
+            try
+            {
+                XnaToFnaHelper.Log("[ProxyForms] GameFormForWinForms: Creating game's Windows Form");
+                var formType = GetFormType();
+                FormInstance = Activator.CreateInstance(formType);
+                // InitializeForm(formType, _formInstance); // No known mod needs this yet.
+                var handleProp = formType.GetProperty(FormClass.Properties.Handle);
+                _handle = (IntPtr)handleProp.GetValue(FormInstance);
+                HookFormToGameExit(game);
+            }
+            catch (Exception ex)
+            {
+                // Fallback for Linux/macOS
+                XnaToFnaHelper.Log("[ProxyForms] GameFormForWinForms: Error while creating game's Windows Form:");
+                XnaToFnaHelper.Log(ex.ToString());
+                _handle = IntPtr.Zero;
+            }
+            _initialized = true;
+        }
+
+        private static Type GetFormType()
+        {
+            var formsAssembly = GetWinFormsAssembly();
+            var formType = formsAssembly.GetType(FormClass.NameWithNamespace);
+            return formType;
+        }
+
+        private static Assembly GetWinFormsAssembly()
+        {
+            var assemblies = AppDomain.CurrentDomain.GetAssemblies();
+            var winFormsAssembly = assemblies.FirstOrDefault(a => a.GetName().Name == WinFormsAssemblyName);
+
+            if (winFormsAssembly != null) {
+                return winFormsAssembly;
+            }
+            // Won't work without the FULL strong name:
+            winFormsAssembly = Assembly.Load(WinFormsAssemblyStrongName);
+            return winFormsAssembly;
+        }
+
+        /// <summary>
+        /// Sets the form to be hidden and calls "Form.Show()" to initialize it.
+        /// In some rare cases, a mod could depend on form events 
+        /// that only trigger if the form has been shown.
+        /// </summary>
+        private static void InitializeForm(Type formType, object windowsFormObj)
+        {
+            formType.GetProperty(FormClass.Properties.ShowInTaskbar)?.SetValue(windowsFormObj, false);
+            formType.GetProperty(FormClass.Properties.FormBorderStyle)?.SetValue(windowsFormObj, 0); // None
+            formType.GetProperty(FormClass.Properties.Opacity)?.SetValue(windowsFormObj, 0.0);
+            formType.GetMethod(FormClass.Methods.Show, Type.EmptyTypes)?.Invoke(windowsFormObj, null);
+        }
+
+        public static void HookFormToGameExit(Game game)
+        {
+            HookFormToGameExit(FormInstance, game);
+        }
+
+        private static void HookFormToGameExit(object form, Game game)
+        {
+            if (form == null || game == null) {
+                return;
+            }
+            game.Exiting += (s, e) => {
+                try {
+                    var close = form.GetType().GetMethod(FormClass.Methods.Close);
+                    close?.Invoke(form, null);
+                    XnaToFnaHelper.Log("[ProxyForms] GameFormForWinForms: Form closed");
+                }
+                catch(Exception ex) {
+                    XnaToFnaHelper.Log("[ProxyForms] GameFormForWinForms: Error trying to run Form's 'Close()' method:");
+                    XnaToFnaHelper.Log(ex.ToString());
+                }
+            };
+        }
+    }
+}

--- a/DuckGame/src/XnaToFna/XnaToFnaHelper.cs
+++ b/DuckGame/src/XnaToFna/XnaToFnaHelper.cs
@@ -37,22 +37,13 @@ namespace XnaToFna
             Console.Write("[XnaToFnaHelper] ");
             Console.WriteLine(s);
         }
-        public static Form fillinform;
+
         public static IntPtr GetProxyFormHandle(this GameWindow window)
         {
-            if (fillinform == null)
-            {
-                fillinform = new Form();
-            }
-            return fillinform.Handle;
-            //if (GameForm.Instance == null)
-            //{
-            //    fillinform = new Form();
-            //    Log("[ProxyForms] Creating game ProxyForms.GameForm");
-            //    GameForm.Instance = new GameForm();
-            //}
-            //return fillinform.Handle;//GameForm.Instance.Handle;
+            return GameForm.GetInstance(MonoMain.instance).Handle;
+            // return GameFormForWinForms.GetHandle(MonoMain.instance); // Alternative that doesn't require relinking WinForms types.
         }
+
         public static DirectoryInfo DirectoryCreateDirectory(string path)
         {
             if (Program.IsLinuxD || Program.isLinux)

--- a/DuckGame/src/XnaToFna/XnaToFnaUtil.cs
+++ b/DuckGame/src/XnaToFna/XnaToFnaUtil.cs
@@ -12,7 +12,6 @@ using System.IO;
 using System.Linq;
 using System.Reflection;
 using System.Security;
-using System.Windows.Media;
 using System.Xml.Serialization;
 using XnaToFna.ProxyForms;
 //using XnaToFna.XEX;


### PR DESCRIPTION
Continuation of [the Part 1](https://github.com/TheFlyingFoool/DuckGameRebuilt/pull/75)

## List of changes:
- Removed unused WinForm's "using" statements.
- Created an `RtfWriter` to replace the use of WinForm's RichTextBox as a way to generate RTF documents.
- Removed WinForms specific exception handling, that is already taken care of by other exception handlers.
- Removed hard references to WinForms from the `SaveTool` logic by using reflection instead.
- Removed WinForms hard references from "Game.Window.Handle" related code in XnaToFna.