### PR TITLE
Remove WindowsForms references (part 3)

### DIFF
--- a/DuckGame/AddedContent/Extensions.cs
+++ b/DuckGame/AddedContent/Extensions.cs
@@ -1,7 +1,5 @@
 ﻿using AddedContent.Firebreak;
 using DuckGame.ConsoleEngine;
-using SixLabors.ImageSharp;
-using SixLabors.ImageSharp.PixelFormats;
 using System;
 using System.Collections;
 using System.Linq;
@@ -10,10 +8,6 @@ using System.Reflection;
 using System.Collections.Generic;
 using System.Text.RegularExpressions;
 using System.Reflection.Emit;
-using System.Diagnostics;
-using System.Drawing;
-using System.Web.UI.WebControls;
-using Image = SixLabors.ImageSharp.Image;
 using SizeF = System.Drawing.SizeF;
 using System.IO;
 

--- a/DuckGame/AddedContent/Firebreak/Content/ThrowingKnife/ThrowingKnife.cs
+++ b/DuckGame/AddedContent/Firebreak/Content/ThrowingKnife/ThrowingKnife.cs
@@ -1,5 +1,4 @@
 using System;
-using System.Drawing.Drawing2D;
 
 namespace DuckGame
 {

--- a/DuckGame/AddedContent/Firebreak/HatEditor/FeatherFashion.cs
+++ b/DuckGame/AddedContent/Firebreak/HatEditor/FeatherFashion.cs
@@ -1,26 +1,31 @@
 using AddedContent.Firebreak;
 using Microsoft.Xna.Framework.Graphics;
 using System;
+using System.Collections.Generic;
 using System.Drawing;
 using System.IO;
 using System.Linq;
 using System.Reflection;
 using System.Security;
 using System.Threading;
-using System.Windows.Forms;
 
 namespace DuckGame
 {
     public partial class FeatherFashion : Level
     {
         public WorkMode CurrentWorkMode = WorkMode.Editor;
-        
         private static uint s_framesUntilTooltip;
         private static string s_toolTipMessage = string.Empty;
         private static bool s_iconBeingHovered;
         private static string s_iconHoveredID = string.Empty;
         private static string? s_filePath = null;
+        private static bool _isFileDialogOpen = false;
+        private static string _hatFileFilterExtension = "png";
+        private static string _hatFileFilterDescription = "PNG files (*.png)";
         private static FileSystemWatcher s_fileWatcher = new();
+        private static SDL3.SDL.SDL_DialogFileFilter[] _hatFileFilter 
+            => FileDialogFna.GetDialogFileFilters(_hatFileFilterDescription, _hatFileFilterExtension);
+
         public static string? HatName => Path.GetFileNameWithoutExtension(FilePath);
 
         public static string FilePath
@@ -36,7 +41,6 @@ namespace DuckGame
             }
         }
 
-        
         [Marker.PostInitialize]
         public static void StaticInitialize()
         {
@@ -355,101 +359,147 @@ namespace DuckGame
         {
             if (rightClick && FilePath is not null)
             {
-                Texture2D texture = TextureConverter.LoadPNGWithPinkAwesomeness(Graphics.device, FilePath, true);
-                
-                if (texture is null)
-                    return;
-
-                if (texture.Width > 100 || texture.Height > 56)
-                    throw new Exception("Image file too big to be a vanilla hat");
-
-                LoadHat(texture);
+                LoadHatFile(FilePath);
                 return;
             }
-            
-            Thread t = new(() =>
+            //RunInMainThread(OpenHatFileDialog);
+            OpenHatFileDialog();
+        }
+
+        private static void LoadHatFile(string filePath)
+        {
+            if (string.IsNullOrEmpty(filePath)) {
+                return;
+            }
+            Texture2D texture = TextureConverter.LoadPNGWithPinkAwesomeness(Graphics.device, filePath, true);
+            if (texture is null)
+                return;
+
+            if (texture.Width > 100 || texture.Height > 56)
+                throw new Exception("Image file too big to be a vanilla hat");
+
+            LoadHat(texture);
+        }
+
+        private static void OpenHatFileDialog()
+        {
+            if (_isFileDialogOpen) {
+                return;
+            }
+            _isFileDialogOpen = true;
+            try
             {
-                try
-                {
-                    OpenFileDialog dialog = new() {Filter = "PNG files (*.png)|*.png"};
-                    if (dialog.ShowDialog() == DialogResult.OK)
-                    {
-                        Texture2D texture = TextureConverter.LoadPNGWithPinkAwesomeness(Graphics.device, dialog.FileName, true);
+                var openDialog = new FileDialogFna();
+                openDialog.ShowOpenFileDialog(OpenFileCallback, window: MonoMain.instance.Window.Handle, filters: _hatFileFilter);
+            }
+            catch (SecurityException ex)
+            {
+                MessageBoxFna.Show($"Security error.\n\nError message: {ex.Message}\n\n" +
+                                   $"Details:\n\n{ex.StackTrace}", icon: MessageBoxFna.Icon.Warning);
+            }
+            catch (Exception e)
+            {
+                DevConsole.Log(e);
+            }
+        }
 
-                        if (texture.Width > 100 || texture.Height > 56)
-                            throw new Exception("Image file too big to be a vanilla hat");
+        private static void OpenFileCallback(List<string> fileNames)
+        {
+            _isFileDialogOpen = false;
+            var fileName = fileNames?.FirstOrDefault();
+            if (string.IsNullOrEmpty(fileName)) {
+                return; // Cancelled.
+            }
+            try
+            {
+                Console.WriteLine($"OpenFile from: {fileName}");
+                Texture2D texture = TextureConverter.LoadPNGWithPinkAwesomeness(Graphics.device, fileName, true);
+                if (texture.Width > 100 || texture.Height > 56) {
+                    throw new Exception("Image file too big to be a vanilla hat");
+                }
+                LoadHat(texture);
+                FilePath = fileName;
+            } catch(Exception ex) {
+                Console.WriteLine("Error opening file: " + ex);
+                MessageBoxFna.Show($"Error opening file: {ex.Message}\n\nDetails:\n\n{ex.StackTrace}");
+            }
+        }
 
-                        LoadHat(texture);
-                        FilePath = dialog.FileName;
-                    }
-                }
-                catch (SecurityException ex)
-                {
-                    MessageBox.Show($"Security error.\n\nError message: {ex.Message}\n\n" +
-                                    $"Details:\n\n{ex.StackTrace}");
-                }
-                catch (Exception e)
-                {
-                    DevConsole.Log(e);
-                }
-            });
-            t.SetApartmentState(ApartmentState.STA);
-            t.Start();
+        private static void SaveFileCallback(string fileName)
+        {
+            _isFileDialogOpen = false;
+            if (string.IsNullOrEmpty(fileName)) {
+                return; // Cancelled
+            }
+            try
+            {
+                Console.WriteLine($"SaveFile to: {fileName}");
+                var fileNameWithExtension = FileDialogFna.EnsureFileExtension(fileName, ".png");
+                FilePath = fileNameWithExtension;
+                GlobalActionSave();
+            } catch (Exception ex) {
+                Console.WriteLine("Error saving file: " + ex);
+                MessageBoxFna.Show($"Error saving file: {ex.Message}\n\nDetails:\n\n{ex.StackTrace}");
+            }
         }
 
         private static void GlobalActionSave(bool alwaysNew = false)
         {
             if (FilePath is not null && !alwaysNew)
             {
-                try
-                {
-                    using FileStream stream = File.OpenWrite(FilePath);
-                    Tex2D fullHatTexture = FFEditorPane.FullHatTexture;
-                    fullHatTexture.SaveAsPng(stream, fullHatTexture.w, fullHatTexture.h);
-                    
-                    HUD.AddPlayerChangeDisplay($"{HatName} saved!", 1f);
-                }
-                catch (Exception e)
-                {
-                    DevConsole.Log(e);
-                    HUD.AddPlayerChangeDisplay("Save failed. Check console for error");
-                    throw;
-                }
+                SaveHatFile(FilePath);
                 return;
             }
             else
             {
-                Thread t = new(() =>
-                {
-                    try
-                    {
-                        SaveFileDialog dialog = new()
-                        {
-                            AddExtension = true,
-                            DefaultExt = "png",
-                            Filter = "PNG files (*.png)|*.png"
-                        };
-                        if (dialog.ShowDialog() == DialogResult.OK)
-                        {
-                            FilePath = dialog.FileName;
-                            GlobalActionSave();
-                        }
-                    }
-                    catch (SecurityException ex)
-                    {
-                        MessageBox.Show($"Security error.\n\nError message: {ex.Message}\n\n" +
-                                        $"Details:\n\n{ex.StackTrace}");
-                    }
-                    catch (Exception e)
-                    {
-                        DevConsole.Log(e);
-                    }
-                });
-                t.SetApartmentState(ApartmentState.STA);
-                t.Start();
+                //RunInMainThread(OpenSaveHatDialog);
+                OpenSaveHatDialog();
             }
         }
-        
+
+        private static void OpenSaveHatDialog()
+        {
+            if (_isFileDialogOpen) {
+                return;
+            }
+            _isFileDialogOpen = true;
+            try
+            {
+                var saveDialog = new FileDialogFna();
+                saveDialog.ShowSaveFileDialog(SaveFileCallback, null, window: MonoMain.instance.Window.Handle, _hatFileFilter);
+            }
+            catch (SecurityException ex)
+            {
+                MessageBoxFna.Show($"Security error.\n\nError message: {ex.Message}\n\n" +
+                                    $"Details:\n\n{ex.StackTrace}");
+            }
+            catch (Exception e)
+            {
+                DevConsole.Log(e);
+            }
+        }
+
+        private static void SaveHatFile(string filePath)
+        {
+            if (string.IsNullOrEmpty(filePath)) {
+                return;
+            }
+            try
+            {
+                using FileStream stream = File.OpenWrite(filePath);
+                Tex2D fullHatTexture = FFEditorPane.FullHatTexture;
+                fullHatTexture.SaveAsPng(stream, fullHatTexture.w, fullHatTexture.h);
+
+                HUD.AddPlayerChangeDisplay($"{HatName} saved!", 1f);
+            }
+            catch (Exception e)
+            {
+                DevConsole.Log(e);
+                HUD.AddPlayerChangeDisplay("Save failed. Check console for error");
+                throw;
+            }
+        }
+
         private static void GlobalActionLeave(bool _)
         {
             current = new TitleScreen();
@@ -504,6 +554,17 @@ namespace DuckGame
                 s_iconHoveredID = "";
                 s_framesUntilTooltip = 0;
             }
+        }
+
+        private static Thread RunInMainThread(Action action)
+        {
+            Thread t = new(() =>
+            {
+                action.Invoke();
+            });
+            t.SetApartmentState(ApartmentState.STA);
+            t.Start();
+            return t;
         }
     }
 }

--- a/DuckGame/AddedContent/Firebreak/Utilities/FileDialogFna.cs
+++ b/DuckGame/AddedContent/Firebreak/Utilities/FileDialogFna.cs
@@ -1,0 +1,121 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using static SDL3.SDL;
+
+namespace DuckGame
+{
+    /// <summary>
+    /// https://wiki.libsdl.org/SDL3/SDL_ShowOpenFileDialog
+    /// https://wiki.libsdl.org/SDL3/SDL_ShowSaveFileDialog
+    /// </summary>
+    public class FileDialogFna
+    {
+        // Use static properties to prevent GC errors by keeping a reference to the callback.
+        // Only supports one type of dialog at a time.
+        public static OpenDialogFileCallback OnOpenFile;
+        public static SaveDialogFileCallback OnSaveFile;
+        public static SDL_DialogFileCallback OnOpenFileCallback;
+        public static SDL_DialogFileCallback OnSaveFileCallback;
+        public delegate void OpenDialogFileCallback(List<string> filepathsSelected);
+        public delegate void SaveDialogFileCallback(string filepathSelected);
+
+        public void ShowOpenFileDialog(
+             OpenDialogFileCallback onOpenFile
+            ,IntPtr? userdata = null
+            ,IntPtr? window = null
+            ,SDL_DialogFileFilter[] filters = null
+            ,string default_location = null
+            ,bool allowMany = false
+        )
+        {
+            OnOpenFile = onOpenFile;
+            OnOpenFileCallback = OpenFileCallback;
+            SDL_ShowOpenFileDialog(OnOpenFileCallback
+                ,userdata ?? IntPtr.Zero
+                ,window ?? IntPtr.Zero
+                ,filters
+                ,filters?.Length ?? 0
+                ,default_location
+                ,allowMany
+            );
+        }
+
+        public void ShowSaveFileDialog(
+             SaveDialogFileCallback onSaveFile
+            ,IntPtr? userdata = null
+            ,IntPtr? window = null
+            ,SDL_DialogFileFilter[] filters = null
+            ,string default_location = null
+        )
+        {
+            OnSaveFile = onSaveFile;
+            OnSaveFileCallback = SaveFileCallback;
+            SDL_ShowSaveFileDialog(OnSaveFileCallback
+               ,userdata ?? IntPtr.Zero
+               ,window ?? IntPtr.Zero
+               ,filters
+               ,filters?.Length ?? 0
+               ,default_location
+           );
+        }
+
+        public static SDL_DialogFileFilter[] GetDialogFileFilters(string name, string pattern)
+        {
+            var filters = new SDL_DialogFileFilter[] {
+                GetDialogFileFilter(name, pattern)
+            };
+            return filters;
+        }
+
+        public unsafe static SDL_DialogFileFilter GetDialogFileFilter(string name, string pattern)
+        {
+            var filter = new SDL_DialogFileFilter {
+                name = MarshalHelper.ToUTF8(name),
+                pattern = MarshalHelper.ToUTF8(pattern)
+            };
+            return filter;
+        }
+
+        private void OpenFileCallback(IntPtr userdata, IntPtr filelistPtr, int filter)
+        {
+            try
+            {
+                var fileNameList = MarshalHelper.StringUTF8PointersToStringList(filelistPtr);
+                if (!fileNameList.Any()) {
+                    return; // Canceled
+                }
+                OnOpenFile?.Invoke(fileNameList);
+            }
+            finally
+            {
+                OnOpenFile = null;
+            }
+        }
+
+        private void SaveFileCallback(IntPtr userdata, IntPtr filelistPtr, int filter)
+        {
+            try
+            {
+                var fileNameList = MarshalHelper.StringUTF8PointersToStringList(filelistPtr);
+                if (!fileNameList.Any()) {
+                    return; // Canceled
+                }
+                OnSaveFile?.Invoke(fileNameList?.FirstOrDefault());
+            }
+            finally {
+                OnSaveFile = null;
+            }
+        }
+
+        public static string EnsureFileExtension(string fileName, string extension)
+        {
+            if (fileName.EndsWith(extension, StringComparison.InvariantCultureIgnoreCase)) {
+                return fileName;
+            }
+            else {
+                return $"{fileName}{extension}";
+            }
+        }
+    }
+}

--- a/DuckGame/AddedContent/Firebreak/Utilities/MarshalHelper.cs
+++ b/DuckGame/AddedContent/Firebreak/Utilities/MarshalHelper.cs
@@ -1,0 +1,54 @@
+﻿using Microsoft.Xna.Framework;
+using System;
+using System.Collections.Generic;
+using System.Runtime.InteropServices;
+
+namespace DuckGame
+{
+    public class MarshalHelper
+    {
+        public unsafe static List<string> StringUTF8PointersToStringList(IntPtr filelistPtr)
+        {
+            var fileNameList = new List<string>();
+            if (filelistPtr == IntPtr.Zero) {
+                return fileNameList;
+            }
+            byte** filelist = (byte**)filelistPtr;
+            int i = 0;
+            while (filelist[i] != null)
+            {
+                // "Marshal.PtrToStringUTF8" is only available in dotnet Core 2.1 or newer.
+                // string fileName = Marshal.PtrToStringUTF8((IntPtr)filelist[i]); 
+                string fileName = PtrToStringUTF8((IntPtr)filelist[i]);
+                fileNameList.Add(fileName);
+                i++;
+            }
+            return fileNameList;
+        }
+
+        public unsafe static byte* ToUTF8(string str)
+        {
+            if (str == null) {
+                return null;
+            }
+            var bytes = System.Text.Encoding.UTF8.GetBytes(str + '\0');
+            var ptr = FNAPlatform.Malloc(bytes.Length);
+            Marshal.Copy(bytes, 0, ptr, bytes.Length);
+            return (byte*)ptr;
+        }
+
+        private static string PtrToStringUTF8(IntPtr ptr)
+        {
+            if (ptr == IntPtr.Zero) {
+                return null;
+            }
+            int len = 0;
+            while (Marshal.ReadByte(ptr, len) != 0) {
+                len++;
+            }
+            byte[] buffer = new byte[len];
+            Marshal.Copy(ptr, buffer, 0, len);
+            return System.Text.Encoding.UTF8.GetString(buffer);
+        }
+    }
+}

--- a/DuckGame/AddedContent/Firebreak/Utilities/MessageBoxFna.cs
+++ b/DuckGame/AddedContent/Firebreak/Utilities/MessageBoxFna.cs
@@ -1,0 +1,24 @@
+﻿using System;
+
+namespace DuckGame
+{
+    public static class MessageBoxFna
+    {
+        public static void Show(string message, string title = "Info", Icon icon = Icon.Info)
+        {
+            if (Program.IS_SDL2) {
+                SDL2.SDL.SDL_ShowSimpleMessageBox((SDL2.SDL.SDL_MessageBoxFlags)icon, title ?? "", message ?? "", IntPtr.Zero);
+            }
+            else {
+                SDL3.SDL.SDL_ShowSimpleMessageBox((SDL3.SDL.SDL_MessageBoxFlags)icon, title ?? "", message ?? "", IntPtr.Zero);
+            }
+        }
+
+        public enum Icon : uint
+        {
+            Error = 0x10,
+            Warning = 0x20,
+            Info = 0x40,
+        }
+    }
+}

--- a/DuckGame/AddedContent/Lucky/ClientOnly/Tape/WarpSlash.cs
+++ b/DuckGame/AddedContent/Lucky/ClientOnly/Tape/WarpSlash.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Drawing.Drawing2D;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;

--- a/DuckGame/DuckGame.csproj
+++ b/DuckGame/DuckGame.csproj
@@ -421,6 +421,8 @@
     <Compile Include="AddedContent\Firebreak\HatEditor\FFPreviewAnimations.cs" />
     <Compile Include="AddedContent\Firebreak\HatEditor\FFPreviewPane.cs" />
     <Compile Include="AddedContent\Firebreak\HatEditor\FFPromptMenu.cs" />
+    <Compile Include="AddedContent\Firebreak\Utilities\MarshalHelper.cs" />
+    <Compile Include="AddedContent\Firebreak\Utilities\FileDialogFna.cs" />
     <Compile Include="AddedContent\Firebreak\HatEditor\HatPreviewLevel.cs" />
     <Compile Include="AddedContent\Firebreak\HatEditor\MetapixelInfo.cs" />
     <Compile Include="AddedContent\Firebreak\HatEditor\SimRenderer.cs" />
@@ -465,6 +467,7 @@
     <Compile Include="AddedContent\Firebreak\Utilities\Markers\MarkerAttribute.cs" />
     <Compile Include="AddedContent\Firebreak\Utilities\Markers\PostInitializeAttribute.cs" />
     <Compile Include="AddedContent\Firebreak\Utilities\Markers\UpdateContextAttribute.cs" />
+    <Compile Include="AddedContent\Firebreak\Utilities\MessageBoxFna.cs" />
     <Compile Include="AddedContent\Firebreak\Utilities\SendToLevel.cs" />
     <Compile Include="AddedContent\Firebreak\Utilities\VanillaSyncedAttribute.cs" />
     <Compile Include="AddedContent\Firebreak\Utilities\WordBoundary.cs" />

--- a/DuckGame/src/DuckGame/Network/DuckNetwork.cs
+++ b/DuckGame/src/DuckGame/Network/DuckNetwork.cs
@@ -1,10 +1,6 @@
-﻿using AddedContent.Firebreak;
-using SDL2;
-using SixLabors.ImageSharp;
-using System;
+﻿using System;
 using System.IO;
 using System.Linq;
-using System.Drawing;
 using System.Threading;
 using System.Collections.Generic;
 using Microsoft.Xna.Framework.Graphics;

--- a/DuckGame/src/DuckGame/Profile/Team.cs
+++ b/DuckGame/src/DuckGame/Profile/Team.cs
@@ -2,7 +2,6 @@
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
-using System.Drawing;
 using System.IO;
 using System.Linq;
 using System.Reflection;
@@ -150,7 +149,7 @@ namespace DuckGame
         {
             try
             {
-                Texture2D texture2D1 = TextureConverter.LoadPNGWithPinkAwesomeness(Graphics.device, new Bitmap(new MemoryStream(pData)), true);
+                Texture2D texture2D1 = TextureConverter.LoadPNGWithPinkAwesomeness(Graphics.device, new System.Drawing.Bitmap(new MemoryStream(pData)), true);
                 double num = texture2D1.Width / 32f % 1f;
                 Team pTeam = deserializeInto;
                 if (pTeam == null)

--- a/DuckGame/src/MonoTime/LevelEditor/MonoFileDialog.cs
+++ b/DuckGame/src/MonoTime/LevelEditor/MonoFileDialog.cs
@@ -8,7 +8,6 @@ using System.Drawing.Drawing2D;
 using System.Drawing.Imaging;
 using System.IO;
 using System.IO.Compression;
-using System.Reflection;
 
 namespace DuckGame
 {


### PR DESCRIPTION
Continuation of the [part 1](https://github.com/TheFlyingFoool/DuckGameRebuilt/pull/75) and [part 2](https://github.com/TheFlyingFoool/DuckGameRebuilt/pull/80). This is probably the last of the series.

## List of changes:

- Migrated FeatherFashion's WinForm's MessageBox to FNA/SDL.
- Migrated FeatherFashion's WinForm's FileOpen and FileSave dialogs to FNA/SDL.
- Removed unused System.Drawing "using" statements.

FeatherFashion should now run on Linux too.