### PR TITLE
Fix DisplayMidgameLobbies default setting to true.

### DIFF
--- a/DuckGame/AddedContent/DGRSettings.cs
+++ b/DuckGame/AddedContent/DGRSettings.cs
@@ -429,7 +429,7 @@ namespace DuckGame
 
         [Marker.AutoConfig] public static bool ExtraLobbyData = false;
 
-        [Marker.AutoConfig] public static bool DisplayMidgameLobbies = false;
+        [Marker.AutoConfig] public static bool DisplayMidgameLobbies = true;
 
         [Marker.AutoConfig] public static bool EditorOnlinePhysics = false;
 


### PR DESCRIPTION
If the setting "DisplayMidgameLobbies" is not set to "true" by default, the next DGR release will stop showing FarmBot's midgame lobbies and players won't know why it happened.