### PR TITLE
Cleanup code: extract constants for color names and mod ids.

### DIFF
--- a/DuckGame/src/MonoTime/Modding/ModLoader/ModConfiguration.cs
+++ b/DuckGame/src/MonoTime/Modding/ModLoader/ModConfiguration.cs
@@ -288,7 +288,13 @@ namespace DuckGame
                 configDocument.Save(configFilePath);
             }
         }
-        
+
+        internal void Disable(string reason)
+        {
+            Disable();
+            error = reason;
+        }
+
         internal void Disable()
         {
             if (disabled)

--- a/DuckGame/src/MonoTime/Modding/ModLoader/ModLoader.cs
+++ b/DuckGame/src/MonoTime/Modding/ModLoader/ModLoader.cs
@@ -1,4 +1,8 @@
 ﻿using AddedContent.Firebreak;
+using HarmonyLoader;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.Emit;
 using Microsoft.CSharp;
 using Mono.Cecil;
 using MonoMod.Utils;
@@ -15,10 +19,6 @@ using System.Text;
 using System.Xml;
 using XnaToFna;
 using File = System.IO.File;
-using HarmonyLoader;
-using Microsoft.CodeAnalysis;
-using Microsoft.CodeAnalysis.CSharp;
-using Microsoft.CodeAnalysis.Emit;
 
 namespace DuckGame
 {
@@ -50,18 +50,78 @@ namespace DuckGame
         internal static string _modString;
         private static List<ulong> brokenclientsidemods = new List<ulong>()
         {
-            2291455300UL,
-            2285058623UL,
-            1704010547UL,
-            1422187117UL,
-            1217536842UL,
-            1337905266UL,
-            1653126591UL,
-            1220996500UL,
-            804666647UL,
-            1198406315UL,
-            1356415641UL
+            ModWorkshopId.NetSkins,
+            ModWorkshopId.CopyCutPasteDuck,
+            ModWorkshopId.QOLMod,
+            ModWorkshopId.WorkshopArcades,
+            ModWorkshopId.ChatUtilities,
+            ModWorkshopId.NametagsAtMatchStart,
+            ModWorkshopId.UnlockModifiers,
+            ModWorkshopId.SkipShut,
+            ModWorkshopId.UnlockHats ,
+            ModWorkshopId.SteamProfiles,
+            ModWorkshopId.TalkingMan
         };
+
+        public static class ModDisabledReason
+        {
+            public static string AlreadyImplementedThanksTo(string modDeveloperName) => AlreadyImplemented + ", Thanks " + modDeveloperName;
+            public const string AlreadyImplemented = "!This mod has been officially implemented";
+            public const string DisabledWhenDebugging = "!This is Disabled mod is Disabled when Debugging!";
+            public static string DoesNotWorkInRebuiltDueTo(string details) => DoesNotWorkInRebuilt + ", " + details;
+            public const string DoesNotWorkInRebuilt = "!This mod does not currently work on Rebuilt!";
+        }
+        private static List<(ulong Id, string Reason)> ModsToDisableIfDgRevisionIsNot1 = new List<(ulong Id, string Reason)>
+        {
+            (ModWorkshopId.SteamProfiles, ModDisabledReason.AlreadyImplementedThanksTo("EIM64!")),
+            (ModWorkshopId.InviteLinks, ModDisabledReason.AlreadyImplementedThanksTo("EIM64!")),
+            (ModWorkshopId.Resolutions, ModDisabledReason.AlreadyImplementedThanksTo("EIM64 || Killer-Fackur!")),
+            (ModWorkshopId.TexturePackMod, ModDisabledReason.AlreadyImplementedThanksTo("Yupdaniel!")),
+            (ModWorkshopId.GlobalMatchingMod, ModDisabledReason.AlreadyImplementedThanksTo("Yupdaniel!")),
+            (ModWorkshopId.SpectatorMod, ModDisabledReason.AlreadyImplementedThanksTo("Yupdaniel || Mr. Potatooh!")),
+            (ModWorkshopId.EightPlayerDuckGame, ModDisabledReason.AlreadyImplementedThanksTo("TheSpicyChef!")),
+            (ModWorkshopId.QOLMod, "!Regrettably, this version of QOL is incompatible with Duck Game 2020!"),
+        };
+
+        private static List<(ulong Id, string Reason)> ModsToDisable = new List<(ulong Id, string Reason)>
+        {
+            // Rebuild mod issues
+            //(ModWorkshopId.CustomArcades, ModDisabledReason.DoesNotWorkInRebuilt),
+            //(ModWorkshopId.BetterChat, ModDisabledReason.DoesNotWorkInRebuiltDueTo("Patching Issues!")), // The issue with "Better Chat" mod was its transpiler of Devconsole.Update which we kill now
+            (ModWorkshopId.MyHarmony, "!Rebuilt Handles this issue, Please Do not put harmony into ur Assembly!"),
+            (ModWorkshopId.AntiAliasingMod, ModDisabledReason.DoesNotWorkInRebuiltDueTo("FNA Render Engine")),
+            (ModWorkshopId.DeltaDuckBot, ModDisabledReason.DoesNotWorkInRebuiltDueTo("Just a Mess of Issues! @Tater")),
+            (ModWorkshopId.BugFixes, ModDisabledReason.DoesNotWorkInRebuiltDueTo("Patching Issues!")), // Bug Fixes harmony issue patching menu elements stuff
+            (ModWorkshopId.BrowseGamesPlus, ModDisabledReason.DoesNotWorkInRebuiltDueTo("Patching Issues!")), // "BROWSE GAMES+" mod has a harmony resolve issue with remapper, but also scuffed issues that exist sepreatly
+            (ModWorkshopId.PublicMidGameLobbiesDGRFix, ModDisabledReason.DoesNotWorkInRebuilt),
+
+            // Also disabled but only under certain conditions:
+            //(ModWorkshopId.Reskins, "!This mod does not currently work on Linux!"),
+            //(ModWorkshopId.ExtraStuff, "!This is Disabled mod is Disable, Because v2 is newer"),
+        };
+
+        /// <summary>
+        /// Patchs in these mods Don't Like the Debugger or debug configuration
+        /// </summary>
+        private static List<(ulong Id, string Reason)> ModsToDisableDuringDebug = new List<(ulong Id, string Reason)>
+        {
+            //(ModWorkshopId.QOLMod, ModDisabledReason.DisabledWhenDebugging),
+            //(ModWorkshopId.CompetitiveTools, ModDisabledReason.DisabledWhenDebugging),
+            (ModWorkshopId.ExtraStuff, ModDisabledReason.DisabledWhenDebugging),
+            (ModWorkshopId.ExtraStuffv2, ModDisabledReason.DisabledWhenDebugging),
+        };
+
+        private static bool DisableModIfReasonFound(ModConfiguration modConfig, List<(ulong Id, string Reason)> modsToDisable)
+        {
+            var reasonToDisableMod = modsToDisable.FirstOrDefault(m => m.Id == modConfig.workshopID);
+            var reasonFound = reasonToDisableMod.Id != 0;
+            if (reasonFound) {
+                modConfig.Disable(reasonToDisableMod.Reason);
+                return true;
+            }
+            return false;
+        }
+
         private static CSharpCodeProvider _provider = null;
         private static CompilerParameters _parameters = null;
         private static string _buildErrorText = null;
@@ -438,110 +498,24 @@ namespace DuckGame
                     }
                     else if (modConfig.majorSupportedRevision != 1)
                     {
-                        if (modConfig.workshopID == 1198406315UL || modConfig.workshopID == 1354346379UL)
+                        if (DisableModIfReasonFound(modConfig, ModsToDisableIfDgRevisionIsNot1))
                         {
-                            modConfig.Disable();
-                            modConfig.error = "!This mod has been officially implemented, Thanks EIM64!";
                             mod = new DisabledMod();
                         }
-                        else if (modConfig.workshopID == 1820667892UL)
-                        {
-                            modConfig.Disable();
-
-                            modConfig.error = "!This mod has been officially implemented, Thanks Yupdaniel!";
-                            mod = new DisabledMod();
-                        }
-                        else if (modConfig.workshopID == 1603886916UL)
-                        {
-                            modConfig.Disable();
-                            modConfig.error = "!This mod has been officially implemented, Thanks Yupdaniel || Mr. Potatooh!";
-                            mod = new DisabledMod();
-                        }
-                        else if (modConfig.workshopID == 796033146UL)
-                        {
-                            modConfig.Disable();
-                            modConfig.error = "!This mod has been officially implemented, Thanks TheSpicyChef!";
-                            mod = new DisabledMod();
-                        }
-                        else if (modConfig.workshopID == 1425615438UL)
-                        {
-                            modConfig.Disable();
-                            modConfig.error = "!This mod has been officially implemented, Thanks EIM64 || Killer-Fackur!";
-                            mod = new DisabledMod();
-                        }
-                        else if (modConfig.workshopID == 1704010547UL)
-                        {
-                            modConfig.Disable();
-                            modConfig.error = "!Regrettably, this version of QOL is incompatible with Duck Game 2020!";
-                            mod = new DisabledMod();
-                        }
-                        else if (modConfig.workshopID == 1657985708UL)
-                        {
-                            modConfig.Disable();
-                            modConfig.error = "!This mod has been officially implemented, Thanks Yupdaniel!";
-                            mod = new DisabledMod();
-                        }
-
                     }
-                    /* rebuild mod issues */
-                    //if (modConfig.workshopID == 2548159573UL) // custom arcade
-                    //{
-                    //    modConfig.Disable();
-                    //    modConfig.error = "!This mod does not currently work on Rebuilt!";
-                    //    mod = new DisabledMod();
-                    //}
-                    //if (modConfig.workshopID == 2320709295UL) // Better Chat the issue with this mod was its transpiler of Devconsole.Update which we kill now
-                    //{
-                    //    modConfig.Disable();
-                    //    modConfig.error = "!This mod does not currently work on Rebuilt, Patching Issues!";
-                    //    mod = new DisabledMod();
-                    //}
-                    if (modConfig.workshopID == 3649111390UL) // My Harmony
+                    if (DisableModIfReasonFound(modConfig, ModsToDisable))
                     {
-                        modConfig.Disable();
-                        modConfig.error = "!Rebuilt Handles this issue, Please Do not put harmony into ur Assembly!";
                         mod = new DisabledMod();
                     }
-                    else if (modConfig.workshopID == 2209935223UL) // DuckAntiAliasing
+                    else if (modConfig.workshopID == ModWorkshopId.Reskins && Program.isLinux && !modConfig.linuxFix)
                     {
-                        modConfig.Disable();
-                        modConfig.error = "!This mod does not work with on Rebuilt FNA Render Engine";
+                        modConfig.Disable("!This mod does not currently work on Linux!");
                         mod = new DisabledMod();
                     }
-                    else if (modConfig.workshopID == 2480332949UL) //Delta Duck
+                    else if (modConfig.workshopID == ModWorkshopId.ExtraStuff
+                      && loadableModIds.Contains(ModWorkshopId.ExtraStuffv2))
                     {
-                        modConfig.Disable();
-                        modConfig.error = "!This mod does not currently work on Rebuilt, Just a Mess of Issues! @Tater";
-                        mod = new DisabledMod();
-                    }
-                    else if (modConfig.workshopID == 2758180905UL) // Bug Fixes harmony issue patching menu elements stuff
-                    {
-                        modConfig.Disable();
-                        modConfig.error = "!This mod does not currently work on Rebuilt, Patching Issues!";
-                        mod = new DisabledMod();
-                    }
-                    else if (modConfig.workshopID == 2674911202UL) // BROWSE GAMES+ has a harmony resolve issue with remapper, but also scuffed issues that exist sepreatly
-                    {
-                        modConfig.Disable();
-                        modConfig.error = "!This mod does not currently work on Rebuilt, Patching Issues!";
-                        mod = new DisabledMod();
-                    }
-                    else if (modConfig.workshopID == 1439906266UL && Program.isLinux && !modConfig.linuxFix) // Reskins
-                    {
-                        modConfig.Disable();
-                        modConfig.error = "!This mod does not currently work on Linux!";
-                        mod = new DisabledMod();
-                    }
-                    else if (modConfig.workshopID == 3386030767UL)
-                    {
-                        modConfig.Disable();
-                        modConfig.error = "!This mod does not currently work on Rebuilt!";
-                        mod = new DisabledMod();
-                    }
-                    else if (modConfig.workshopID == 2381384850UL && loadableModIds.Contains(2586315559))
-                    {
-                        modConfig.Disable();
-                        modConfig.error = "!This is Disabled mod is Disable, Because v2 is newer";
+                        modConfig.Disable("!This is Disabled mod is Disable, Because v2 is newer");
                         mod = new DisabledMod();
                     }
 
@@ -549,37 +523,13 @@ namespace DuckGame
 #if DEBUG
                     //if (true)
 #else
-                        if (Debugger.IsAttached)
+                    if (Debugger.IsAttached)
 #endif
-                    //{
-                        //if (modConfig.name == "QOL")
-                        //{
-                        //    modConfig.Disable();
-                        //    modConfig.error = "!This is Disabled mod is Disabled when Debugging!";
-                        //    mod = new DisabledMod();
-                        //}
-                        //else
-                        //if (modConfig.workshopID == 2411996803UL) //CLIENT | Competitive Tools https://steamcommunity.com/sharedfiles/filedetails/?id=2411996803
-                        //{
-                        //    modConfig.Disable();
-                        //    modConfig.error = "!This is Disabled mod is Disabled when Debugging!";
-                        //    mod = new DisabledMod();
-                        //}
-                        //else
-                        if (modConfig.workshopID == 2381384850UL) //Extrastuff https://steamcommunity.com/sharedfiles/filedetails/?id=2381384850
-                        {
-                            modConfig.Disable();
-                            modConfig.error = "!This is Disabled mod is Disabled when Debugging!";
-                            mod = new DisabledMod();
-                        }
-                        else
-                        if (modConfig.workshopID == 2586315559) //Extrastuff v2 https://steamcommunity.com/sharedfiles/filedetails/?id=2586315559
-                        {
-                            modConfig.Disable();
-                            modConfig.error = "!This is Disabled mod is Disabled when Debugging!";
-                            mod = new DisabledMod();
-                        }
-                    //}
+
+                    if (DisableModIfReasonFound(modConfig, ModsToDisableDuringDebug))
+                    {
+                        mod = new DisabledMod();
+                    }
                 }
                 if (mod == null)
                 {
@@ -1574,5 +1524,42 @@ namespace DuckGame
             _modsByWorkshopID.TryGetValue(pID, out modFromWorkshopId);
             return modFromWorkshopId;
         }
+    }
+
+    public static class ModWorkshopId
+    {
+        // To view the mod's steam workshop page, add the ID to this url:
+        // https://steamcommunity.com/sharedfiles/filedetails/?id=
+
+        public const ulong NetSkins = 2291455300;
+        public const ulong CopyCutPasteDuck = 2285058623;
+        public const ulong QOLMod = 1704010547;
+        public const ulong WorkshopArcades = 1422187117;
+        public const ulong ChatUtilities = 1217536842;
+        public const ulong NametagsAtMatchStart = 1337905266;
+        public const ulong UnlockModifiers = 1653126591;
+        public const ulong SkipShut = 1220996500;
+        public const ulong UnlockHats = 804666647;
+        public const ulong SteamProfiles = 1198406315;
+        public const ulong TalkingMan = 1356415641;
+
+        public const ulong InviteLinks = 1354346379;
+        public const ulong TexturePackMod = 1820667892;
+        public const ulong SpectatorMod = 1603886916;
+        public const ulong EightPlayerDuckGame = 796033146;
+        public const ulong Resolutions = 1425615438;
+        public const ulong GlobalMatchingMod = 1657985708;
+        public const ulong CustomArcades = 2548159573;
+        public const ulong BetterChat = 2320709295;
+        public const ulong MyHarmony = 3649111390;
+        public const ulong AntiAliasingMod = 2209935223;
+        public const ulong DeltaDuckBot = 2480332949;
+        public const ulong BugFixes = 2758180905;
+        public const ulong BrowseGamesPlus = 2674911202;
+        public const ulong Reskins = 1439906266;
+        public const ulong PublicMidGameLobbiesDGRFix = 3386030767;
+        public const ulong ExtraStuff = 2381384850;
+        public const ulong ExtraStuffv2 = 2586315559;
+        public const ulong CompetitiveTools = 2411996803;
     }
 }

--- a/DuckGame/src/MonoTime/Render/Colors.cs
+++ b/DuckGame/src/MonoTime/Render/Colors.cs
@@ -3,6 +3,54 @@ using System.Collections.Generic;
 
 namespace DuckGame
 {
+    public static class ColorName
+    {
+        public const string PREV = "PREV";
+        public const string AQUA = "AQUA";
+        public const string RED = "RED";
+        public const string WHITE = "WHITE";
+        public const string BLACK = "BLACK";
+        public const string DARKNESS = "DARKNESS";
+        public const string BLUE = "BLUE";
+        public const string DGBLUE = "DGBLUE";
+        public const string DGRED = "DGRED";
+        public const string DGREDDD = "DGREDDD";
+        public const string DGGREEN = "DGGREEN";
+        public const string DGGREENN = "DGGREENN";
+        public const string DGYELLOW = "DGYELLOW";
+        public const string DGYELLO = "DGYELLO";
+        public const string DGORANGE = "DGORANGE";
+        public const string ORANGE = "ORANGE";
+        public const string MENUORANGE = "MENUORANGE";
+        public const string YELLOW = "YELLOW";
+        public const string GREEN = "GREEN";
+        public const string LIME = "LIME";
+        public const string TIMELIME = "TIMELIME";
+        public const string GRAY = "GRAY";
+        public const string LIGHTGRAY = "LIGHTGRAY";
+        public const string CREDITSGRAY = "CREDITSGRAY";
+        public const string BLUEGRAY = "BLUEGRAY";
+        public const string PINK = "PINK";
+        public const string PURPLE = "PURPLE";
+        public const string DGPURPLE = "DGPURPLE";
+        public const string CBRONZE = "CBRONZE";
+        public const string CSILVER = "CSILVER";
+        public const string CGOLD = "CGOLD";
+        public const string CPLATINUM = "CPLATINUM";
+        public const string CDEV = "CDEV";
+        public const string DUCKCOLOR1 = "DUCKCOLOR1";
+        public const string DUCKCOLOR2 = "DUCKCOLOR2";
+        public const string DUCKCOLOR3 = "DUCKCOLOR3";
+        public const string DUCKCOLOR4 = "DUCKCOLOR4";
+        public const string RBOW_1 = "RBOW_1";
+        public const string RBOW_2 = "RBOW_2";
+        public const string RBOW_3 = "RBOW_3";
+        public const string RBOW_4 = "RBOW_4";
+        public const string RBOW_5 = "RBOW_5";
+        public const string RBOW_6 = "RBOW_6";
+        public const string RBOW_7 = "RBOW_7";
+    }
+
     public class Colors
     {
         public static Color MenuOption = new Color(235, 137, 51);
@@ -29,7 +77,7 @@ namespace DuckGame
         public static Color Duck4 = new Color(205, 107, 29);
         public static Color SuperDarkBlueGray = new Color(8, 12, 16);
         public static Color SystemGray = new Color(173, 173, 173);
-        public static Color[] Rainbow = new Color[] { 
+        public static Color[] Rainbow = new Color[] {
             new Color(255, 0, 0),
             new Color(255, 127, 0),
             new Color(255, 255, 0),
@@ -41,181 +89,54 @@ namespace DuckGame
             new Color(0, 0, 255),
             new Color(127, 0, 255),
             new Color(255, 0, 255),
-            new Color(255, 0, 127) };
+            new Color(255, 0, 127)
+        };
+
         private static Dictionary<string, Color> _colorMap = new Dictionary<string, Color>()
         {
-            {
-                "AQUA",
-                new Color(0, (int) byte.MaxValue, (int) byte.MaxValue, (int) byte.MaxValue)
-            },
-            {
-                "RED",
-                Color.Red
-            },
-            {
-                "WHITE",
-                Color.White
-            },
-            {
-                "BLACK",
-                Color.Black
-            },
-            {
-                "DARKNESS",
-                new Color(10, 10, 10)
-            },
-            {
-                "BLUE",
-                Color.Blue
-            },
-            {
-                "DGBLUE",
-                DGBlue
-            },
-            {
-                "DGRED",
-                DGRed
-            },
-            {
-                "DGREDDD",
-                DGRed
-            },
-            {
-                "DGGREEN",
-                DGGreen
-            },
-            {
-                "DGGREENN",
-                DGGreen
-            },
-            {
-                "DGYELLOW",
-                DGYellow
-            },
-            {
-                "DGYELLO",
-                DGYellow
-            },
-            {
-                "DGORANGE",
-                new Color(235, 136, 49)
-            },
-            {
-                "ORANGE",
-                new Color(235, 137, 51)
-            },
-            {
-                "MENUORANGE",
-                MenuOption
-            },
-            {
-                "YELLOW",
-                new Color(247, 224, 90)
-            },
-            {
-                "GREEN",
-                Color.LimeGreen
-            },
-            {
-                "LIME",
-                Color.LimeGreen
-            },
-            {
-                "TIMELIME",
-                Color.Lime
-            },
-            {
-                "GRAY",
-                new Color(70, 70, 70)
-            },
-            {
-                "LIGHTGRAY",
-                new Color(96, 119, 124)
-            },
-            {
-                "CREDITSGRAY",
-                new Color(137, 159, 164)
-            },
-            {
-                "BLUEGRAY",
-                BlueGray
-            },
-            {
-                "PINK",
-                DGPink
-            },
-            {
-                "PURPLE",
-                new Color(115, 48, 242)
-            },
-            {
-                "DGPURPLE",
-                new Color(115, 48, 242)
-            },
-            {
-                "CBRONZE",
-                Bronze
-            },
-            {
-                "CSILVER",
-                Silver
-            },
-            {
-                "CGOLD",
-                Gold
-            },
-            {
-                "CPLATINUM",
-                Platinum
-            },
-            {
-                "CDEV",
-                Developer
-            },
-            {
-                "DUCKCOLOR1",
-                Duck1
-            },
-            {
-                "DUCKCOLOR2",
-                Duck2
-            },
-            {
-                "DUCKCOLOR3",
-                Duck3
-            },
-            {
-                "DUCKCOLOR4",
-                Duck4
-            },
-            {
-                "RBOW_1",
-                new Color(192, 35, 45)
-            },
-            {
-                "RBOW_2",
-                new Color(237, 94, 238)
-            },
-            {
-                "RBOW_3",
-                new Color(138, 38, 190)
-            },
-            {
-                "RBOW_4",
-                new Color(49, 162, 242)
-            },
-            {
-                "RBOW_5",
-                new Color(149, 188, 37)
-            },
-            {
-                "RBOW_6",
-                new Color(247, 224, 90)
-            },
-            {
-                "RBOW_7",
-                new Color(235, 137, 49)
-            }
+            { ColorName.AQUA, new Color(0, (int) byte.MaxValue, (int) byte.MaxValue, (int) byte.MaxValue) },
+            { ColorName.RED, Color.Red },
+            { ColorName.WHITE, Color.White },
+            { ColorName.BLACK, Color.Black },
+            { ColorName.DARKNESS, new Color(10, 10, 10) },
+            { ColorName.BLUE, Color.Blue },
+            { ColorName.DGBLUE, DGBlue },
+            { ColorName.DGRED, DGRed },
+            { ColorName.DGREDDD, DGRed },
+            { ColorName.DGGREEN, DGGreen },
+            { ColorName.DGGREENN, DGGreen },
+            { ColorName.DGYELLOW, DGYellow },
+            { ColorName.DGYELLO, DGYellow },
+            { ColorName.DGORANGE, new Color(235, 136, 49) },
+            { ColorName.ORANGE, new Color(235, 137, 51) },
+            { ColorName.MENUORANGE, MenuOption },
+            { ColorName.YELLOW, new Color(247, 224, 90) },
+            { ColorName.GREEN, Color.LimeGreen },
+            { ColorName.LIME, Color.LimeGreen },
+            { ColorName.TIMELIME, Color.Lime },
+            { ColorName.GRAY, new Color(70, 70, 70) },
+            { ColorName.LIGHTGRAY, new Color(96, 119, 124) },
+            { ColorName.CREDITSGRAY, new Color(137, 159, 164) },
+            { ColorName.BLUEGRAY, BlueGray },
+            { ColorName.PINK, DGPink },
+            { ColorName.PURPLE, new Color(115, 48, 242) },
+            { ColorName.DGPURPLE, new Color(115, 48, 242) },
+            { ColorName.CBRONZE, Bronze },
+            { ColorName.CSILVER, Silver },
+            { ColorName.CGOLD, Gold },
+            { ColorName.CPLATINUM, Platinum },
+            { ColorName.CDEV, Developer },
+            { ColorName.DUCKCOLOR1, Duck1 },
+            { ColorName.DUCKCOLOR2, Duck2 },
+            { ColorName.DUCKCOLOR3, Duck3 },
+            { ColorName.DUCKCOLOR4, Duck4 },
+            { ColorName.RBOW_1, new Color(192, 35, 45) },
+            { ColorName.RBOW_2, new Color(237, 94, 238) },
+            { ColorName.RBOW_3, new Color(138, 38, 190) },
+            { ColorName.RBOW_4, new Color(49, 162, 242) },
+            { ColorName.RBOW_5, new Color(149, 188, 37) },
+            { ColorName.RBOW_6, new Color(247, 224, 90) },
+            { ColorName.RBOW_7, new Color(235, 137, 49) }
         };
         private static float HueToRGB(float v1, float v2, float vH)
         {


### PR DESCRIPTION
Code cleanup:
- Extracted constants for color names and organize color dictionary in a readable format.
- Extracted constants for Mod's WorkshopIds with their respective mod name.
- Grouped disabled mods in their corresponding lists to reuse logic preventing "If-else hell".

Resulting code is meant to be more readable and easier to maintain.
The logic is meant to be the same as before.
