### PR TITLE
Fix: TargetFrameRate setter used stale value and ignored vsync

### DIFF
--- a/DuckGame/AddedContent/DGRSettings.cs
+++ b/DuckGame/AddedContent/DGRSettings.cs
@@ -314,19 +314,10 @@ namespace DuckGame
             set
             {
                 MonoMain.graphics.SynchronizeWithVerticalRetrace = value;
-                //when vsync is ON we never want to use the draw rate limiter because vsync will do that
-                if (value)
-                {
-                    Program.main.UseDrawRateLimiter = false;
-                }
-                //when vsync is OFF we only want to use the rate limiter if:
-                //Uncapped FPS is on && The user has set a target fps that is not 0
-                else
-                {
-                    Program.main.UseDrawRateLimiter = (UncappedFPS && TargetFrameRate != 0);
-                }
-
                 S_UseVSync = value;
+                // Rate limiter is also applied as a safety net: vsync silently fails to cap on some
+                // setups (G-Sync / FreeSync / certain windowed configs), so honor FPS Target regardless.
+                Program.main.UseDrawRateLimiter = UncappedFPS && TargetFrameRate >= 60;
                 MonoMain.graphics.ApplyChanges();
             }
         }
@@ -343,17 +334,9 @@ namespace DuckGame
             }
             set
             {
-                if (value >= 60)
-                {
-                    Program.main.DrawRateLimiterTarget = S_TargetFrameRate;
-                    Program.main.UseDrawRateLimiter = true;
-                    S_TargetFrameRate = value;
-                }
-                else
-                {
-                    Program.main.UseDrawRateLimiter = false;
-                    S_TargetFrameRate = 0;
-                }
+                S_TargetFrameRate = value >= 60 ? value : 0;
+                Program.main.DrawRateLimiterTarget = Math.Max(S_TargetFrameRate, 60);
+                Program.main.UseDrawRateLimiter = UncappedFPS && S_TargetFrameRate >= 60;
             }
         }
 
@@ -362,7 +345,7 @@ namespace DuckGame
             MonoMain.graphics.SynchronizeWithVerticalRetrace = UseVSync;
             Program.main.UnFixedDraw = UncappedFPS;
             Program.main.DrawRateLimiterTarget = Math.Max(TargetFrameRate,60);
-            Program.main.UseDrawRateLimiter = !UseVSync && UncappedFPS && TargetFrameRate >= 60;
+            Program.main.UseDrawRateLimiter = UncappedFPS && TargetFrameRate >= 60;
 
 
             Program.main.TargetElapsedTime = TimeSpan.FromTicks(163934); // Default to 61ups -Lucky

--- a/DuckGame/src/MonoTime/Options.cs
+++ b/DuckGame/src/MonoTime/Options.cs
@@ -534,7 +534,7 @@ namespace DuckGame
             });
             menu.Add(new UIMenuItemToggle("Use V-Sync", field: new FieldBinding(typeof(DGRSettings), nameof(DGRSettings.UseVSync)))
             {
-                dgrDescription = "Verticaly synced drawing, overrides FPS target (REQUIRES RESTART)"
+                dgrDescription = "Vertically synced drawing. Works alongside FPS Target as a cap (REQUIRES RESTART)"
             });
 
             menu.Add(new UIMenuItemNumber("FPS Target", field: new FieldBinding(typeof(DGRSettings), nameof(DGRSettings.TargetFrameRate), 0, 1000, 60), step: 60)


### PR DESCRIPTION
Closes #59.

Two distinct bugs in the FPS settings path:

## Bug A — `TargetFrameRate` setter used a stale backing-field value

The setter assigned `Program.main.DrawRateLimiterTarget = S_TargetFrameRate` *before* storing the new `value` into `S_TargetFrameRate`, so the limiter target was always one step behind the slider. Also unconditionally set `UseDrawRateLimiter = true`, ignoring vsync. Rewrote to store `value` first, use `Math.Max(S_TargetFrameRate, 60)` for parity with `InitalizeFPSThings()`, and respect `UncappedFPS`.

## Bug B — Rate limiter disabled at startup when vsync is on

`InitalizeFPSThings()` set `UseDrawRateLimiter = !UseVSync && UncappedFPS && TargetFrameRate >= 60` — explicitly disabling the limiter when vsync is on, trusting vsync alone to cap FPS. On the reporter's setup (and likely many others — adaptive sync / G-Sync / FreeSync / certain windowed configs), vsync silently fails to actually cap and the user sees 3000+ FPS at startup.

The reporter's existing workaround — "nudge the slider 240 → 180 → 240" — works precisely because the buggy `TargetFrameRate` setter force-enabled the rate limiter. We make the rate limiter a safety net on the load path too: enabled whenever `UncappedFPS && TargetFrameRate >= 60`, regardless of vsync. `UseVSync` setter updated to match so the three apply paths (`UseVSync` setter, `TargetFrameRate` setter, `InitalizeFPSThings`) all use the same calculation.

Also updated the V-Sync menu description (which said it "overrides FPS Target") and fixed the "Verticaly" typo while there.

> Note: with this PR, `FPS Target` and `V-Sync` coexist (lower cap wins) instead of vsync overriding the target. For users on working-vsync setups, this is a no-op unless they set `FPS Target` lower than their refresh rate. If you'd prefer to keep the existing semantics and address #59 a different way (e.g. log when `ApplyChanges()` fails to honor vsync), happy to rework.

## Test plan
- [x] Builds clean (~200 warnings as expected, no new ones)
- [x] Set `FPS Target = 240`, restart with V-Sync ON → cap holds at 240 (was 3000+)
- [x] Set `FPS Target = 240`, restart with V-Sync OFF → cap holds at 240
- [x] Set `FPS Target = 0`, restart → uncapped (limiter disabled)
- [x] Set `FPS Target = 240 → 180 → 240` live without restart → cap follows slider exactly each step